### PR TITLE
Add GitHub Actions pipeline to build and run examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up dependencies
+        run: sudo ./scripts/setup_dependencies.sh
+      - name: Build project
+        run: ./scripts/build.sh
+      - name: Run examples
+        run: ./scripts/run.sh


### PR DESCRIPTION
## Summary
- run existing build and example scripts in CI

## Testing
- `./scripts/build.sh`
- `./scripts/run.sh 2>&1 | tail -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68a4b88f4a8c832aac60f2e5fc0e955d