### PR TITLE
Template solver types and add autodiff derivatives

### DIFF
--- a/include/multi_agent_solver/autodiff_derivatives.hpp
+++ b/include/multi_agent_solver/autodiff_derivatives.hpp
@@ -1,0 +1,287 @@
+#pragma once
+#include <vector>
+
+#include <cppad/cppad.hpp>
+#include <Eigen/Dense>
+
+#include "multi_agent_solver/integrator.hpp"
+#include "multi_agent_solver/types.hpp"
+
+namespace mas
+{
+// Dynamics jacobians -------------------------------------------------
+inline Eigen::MatrixXd
+autodiff_dynamics_state_jacobian( const MotionModel<>& dynamics, const State<>& x,
+                                  const Control<>& u )
+{
+  using ADScalar = CppAD::AD<double>;
+  const int nx   = x.size();
+  const int nu   = u.size();
+  std::vector<ADScalar> x_ad( nx );
+  for( int i = 0; i < nx; ++i )
+    x_ad[i] = x( i );
+  CppAD::Independent( x_ad );
+
+  State<ADScalar>  x_eig( nx );
+  Control<ADScalar> u_eig( nu );
+  for( int i = 0; i < nx; ++i )
+    x_eig( i ) = x_ad[i];
+  for( int i = 0; i < nu; ++i )
+    u_eig( i ) = ADScalar( u( i ) );
+
+  State<ADScalar> y = dynamics( x_eig, u_eig );
+  std::vector<ADScalar> y_ad( nx );
+  for( int i = 0; i < nx; ++i )
+    y_ad[i] = y( i );
+
+  CppAD::ADFun<double> f( x_ad, y_ad );
+  std::vector<double>   x_val( nx );
+  for( int i = 0; i < nx; ++i )
+    x_val[i] = x( i );
+  std::vector<double> jac = f.Jacobian( x_val );
+  Eigen::MatrixXd     J( nx, nx );
+  for( int i = 0; i < nx; ++i )
+    for( int j = 0; j < nx; ++j )
+      J( i, j ) = jac[i * nx + j];
+  return J;
+}
+
+inline Eigen::MatrixXd
+autodiff_dynamics_control_jacobian( const MotionModel<>& dynamics, const State<>& x,
+                                    const Control<>& u )
+{
+  using ADScalar = CppAD::AD<double>;
+  const int nx   = x.size();
+  const int nu   = u.size();
+  std::vector<ADScalar> u_ad( nu );
+  for( int i = 0; i < nu; ++i )
+    u_ad[i] = u( i );
+  CppAD::Independent( u_ad );
+
+  State<ADScalar>  x_eig = x.cast<ADScalar>();
+  Control<ADScalar> u_eig( nu );
+  for( int i = 0; i < nu; ++i )
+    u_eig( i ) = u_ad[i];
+
+  State<ADScalar> y = dynamics( x_eig, u_eig );
+  std::vector<ADScalar> y_ad( nx );
+  for( int i = 0; i < nx; ++i )
+    y_ad[i] = y( i );
+
+  CppAD::ADFun<double> f( u_ad, y_ad );
+  std::vector<double>   u_val( nu );
+  for( int i = 0; i < nu; ++i )
+    u_val[i] = u( i );
+  std::vector<double> jac = f.Jacobian( u_val );
+  Eigen::MatrixXd     J( nx, nu );
+  for( int i = 0; i < nx; ++i )
+    for( int j = 0; j < nu; ++j )
+      J( i, j ) = jac[i * nu + j];
+  return J;
+}
+
+// Cost derivatives ----------------------------------------------------
+inline Eigen::VectorXd
+autodiff_cost_state_gradient( const StageCostFunction<>& cost, const State<>& x, const Control<>& u,
+                              size_t t )
+{
+  using ADScalar = CppAD::AD<double>;
+  const int nx   = x.size();
+  std::vector<ADScalar> x_ad( nx );
+  for( int i = 0; i < nx; ++i )
+    x_ad[i] = x( i );
+  CppAD::Independent( x_ad );
+
+  State<ADScalar>  x_eig( nx );
+  Control<ADScalar> u_eig = u.cast<ADScalar>();
+  for( int i = 0; i < nx; ++i )
+    x_eig( i ) = x_ad[i];
+
+  std::vector<ADScalar> y( 1 );
+  y[0] = cost( x_eig, u_eig, t );
+
+  CppAD::ADFun<double> f( x_ad, y );
+  std::vector<double>   x_val( nx );
+  for( int i = 0; i < nx; ++i )
+    x_val[i] = x( i );
+  std::vector<double> jac = f.Jacobian( x_val );
+  Eigen::VectorXd     g( nx );
+  for( int i = 0; i < nx; ++i )
+    g( i ) = jac[i];
+  return g;
+}
+
+inline Eigen::VectorXd
+autodiff_cost_control_gradient( const StageCostFunction<>& cost, const State<>& x, const Control<>& u,
+                                size_t t )
+{
+  using ADScalar = CppAD::AD<double>;
+  const int nu   = u.size();
+  std::vector<ADScalar> u_ad( nu );
+  for( int i = 0; i < nu; ++i )
+    u_ad[i] = u( i );
+  CppAD::Independent( u_ad );
+
+  State<ADScalar>  x_eig = x.cast<ADScalar>();
+  Control<ADScalar> u_eig( nu );
+  for( int i = 0; i < nu; ++i )
+    u_eig( i ) = u_ad[i];
+
+  std::vector<ADScalar> y( 1 );
+  y[0] = cost( x_eig, u_eig, t );
+
+  CppAD::ADFun<double> f( u_ad, y );
+  std::vector<double>   u_val( nu );
+  for( int i = 0; i < nu; ++i )
+    u_val[i] = u( i );
+  std::vector<double> jac = f.Jacobian( u_val );
+  Eigen::VectorXd     g( nu );
+  for( int i = 0; i < nu; ++i )
+    g( i ) = jac[i];
+  return g;
+}
+
+inline Eigen::MatrixXd
+autodiff_cost_state_hessian( const StageCostFunction<>& cost, const State<>& x, const Control<>& u,
+                               size_t t )
+{
+  using ADScalar = CppAD::AD<double>;
+  const int nx   = x.size();
+  std::vector<ADScalar> x_ad( nx );
+  for( int i = 0; i < nx; ++i )
+    x_ad[i] = x( i );
+  CppAD::Independent( x_ad );
+
+  State<ADScalar>  x_eig( nx );
+  Control<ADScalar> u_eig = u.cast<ADScalar>();
+  for( int i = 0; i < nx; ++i )
+    x_eig( i ) = x_ad[i];
+
+  std::vector<ADScalar> y( 1 );
+  y[0] = cost( x_eig, u_eig, t );
+  CppAD::ADFun<double> f( x_ad, y );
+
+  std::vector<double> x_val( nx );
+  for( int i = 0; i < nx; ++i )
+    x_val[i] = x( i );
+  std::vector<double> h = f.Hessian( x_val, 0 );
+  Eigen::MatrixXd     H( nx, nx );
+  for( int i = 0; i < nx; ++i )
+    for( int j = 0; j < nx; ++j )
+      H( i, j ) = h[i * nx + j];
+  return H;
+}
+
+inline Eigen::MatrixXd
+autodiff_cost_control_hessian( const StageCostFunction<>& cost, const State<>& x, const Control<>& u,
+                                 size_t t )
+{
+  using ADScalar = CppAD::AD<double>;
+  const int nu   = u.size();
+  std::vector<ADScalar> u_ad( nu );
+  for( int i = 0; i < nu; ++i )
+    u_ad[i] = u( i );
+  CppAD::Independent( u_ad );
+
+  State<ADScalar>  x_eig = x.cast<ADScalar>();
+  Control<ADScalar> u_eig( nu );
+  for( int i = 0; i < nu; ++i )
+    u_eig( i ) = u_ad[i];
+
+  std::vector<ADScalar> y( 1 );
+  y[0] = cost( x_eig, u_eig, t );
+  CppAD::ADFun<double> f( u_ad, y );
+
+  std::vector<double> u_val( nu );
+  for( int i = 0; i < nu; ++i )
+    u_val[i] = u( i );
+  std::vector<double> h = f.Hessian( u_val, 0 );
+  Eigen::MatrixXd     H( nu, nu );
+  for( int i = 0; i < nu; ++i )
+    for( int j = 0; j < nu; ++j )
+      H( i, j ) = h[i * nu + j];
+  return H;
+}
+
+inline Eigen::MatrixXd
+autodiff_cost_cross_term( const StageCostFunction<>& cost, const State<>& x, const Control<>& u, size_t t )
+{
+  using ADScalar = CppAD::AD<double>;
+  const int nx   = x.size();
+  const int nu   = u.size();
+  const int n    = nx + nu;
+
+  std::vector<ADScalar> xu_ad( n );
+  for( int i = 0; i < nx; ++i )
+    xu_ad[i] = x( i );
+  for( int i = 0; i < nu; ++i )
+    xu_ad[nx + i] = u( i );
+  CppAD::Independent( xu_ad );
+
+  State<ADScalar>  x_eig( nx );
+  Control<ADScalar> u_eig( nu );
+  for( int i = 0; i < nx; ++i )
+    x_eig( i ) = xu_ad[i];
+  for( int i = 0; i < nu; ++i )
+    u_eig( i ) = xu_ad[nx + i];
+
+  std::vector<ADScalar> y( 1 );
+  y[0] = cost( x_eig, u_eig, t );
+  CppAD::ADFun<double> f( xu_ad, y );
+
+  std::vector<double> xu_val( n );
+  for( int i = 0; i < n; ++i )
+    xu_val[i] = ( i < nx ) ? x( i ) : u( i - nx );
+  std::vector<double> h = f.Hessian( xu_val, 0 );
+  Eigen::MatrixXd     H = Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>( h.data(), n, n );
+  return H.block( nx, 0, nu, nx );
+}
+
+// Gradient of trajectory cost wrt control sequence
+template <typename Dynamics, typename Stage, typename Terminal>
+inline ControlGradient
+autodiff_trajectory_gradient( const State<>& x0, const ControlTrajectory& controls, const Dynamics& dynamics,
+                              const Stage& stage_cost, const Terminal& terminal_cost, double dt )
+{
+  using ADScalar = CppAD::AD<double>;
+  const int nu   = controls.rows();
+  const int T    = controls.cols();
+  const int nvar = nu * T;
+
+  std::vector<ADScalar> u_ad( nvar );
+  for( int t = 0; t < T; ++t )
+    for( int i = 0; i < nu; ++i )
+      u_ad[t * nu + i] = controls( i, t );
+  CppAD::Independent( u_ad );
+
+  ControlTrajectoryT<ADScalar> U( nu, T );
+  for( int t = 0; t < T; ++t )
+    for( int i = 0; i < nu; ++i )
+      U( i, t ) = u_ad[t * nu + i];
+
+  State<ADScalar> x_init = x0.cast<ADScalar>();
+  StateTrajectoryT<ADScalar> X
+    = integrate_horizon<ADScalar>( x_init, U, dt, dynamics, integrate_rk4<ADScalar> );
+
+  ADScalar cost = 0.0;
+  for( int t = 0; t < T; ++t )
+    cost += stage_cost( X.col( t ), U.col( t ), t );
+  cost += terminal_cost( X.col( T ) );
+
+  std::vector<ADScalar> y( 1 );
+  y[0] = cost;
+  CppAD::ADFun<double> f( u_ad, y );
+
+  std::vector<double> u_val( nvar );
+  for( int t = 0; t < T; ++t )
+    for( int i = 0; i < nu; ++i )
+      u_val[t * nu + i] = controls( i, t );
+  std::vector<double> grad = f.Jacobian( u_val );
+
+  ControlGradient G( nu, T );
+  for( int t = 0; t < T; ++t )
+    for( int i = 0; i < nu; ++i )
+      G( i, t ) = grad[t * nu + i];
+  return G;
+}
+} // namespace mas

--- a/include/multi_agent_solver/integrator.hpp
+++ b/include/multi_agent_solver/integrator.hpp
@@ -9,35 +9,42 @@ namespace mas
 {
 
 // Single-step Euler integration
-inline State
-integrate_euler( const State& current_state, const Control& control, double dt, const MotionModel& motion_model )
+template <typename Scalar = double>
+inline State<Scalar>
+integrate_euler( const State<Scalar>& current_state, const Control<Scalar>& control, double dt,
+                 const MotionModel<Scalar>& motion_model )
 {
   return current_state + dt * motion_model( current_state, control );
 }
 
 // Single-step RK4 integration
-inline State
-integrate_rk4( const State& current_state, const Control& control, double dt, const MotionModel& motion_model )
+template <typename Scalar = double>
+inline State<Scalar>
+integrate_rk4( const State<Scalar>& current_state, const Control<Scalar>& control, double dt,
+               const MotionModel<Scalar>& motion_model )
 {
-  State k1 = motion_model( current_state, control );
-  State k2 = motion_model( current_state + 0.5 * dt * k1, control );
-  State k3 = motion_model( current_state + 0.5 * dt * k2, control );
-  State k4 = motion_model( current_state + dt * k3, control );
+  State<Scalar> k1 = motion_model( current_state, control );
+  State<Scalar> k2 = motion_model( current_state + 0.5 * dt * k1, control );
+  State<Scalar> k3 = motion_model( current_state + 0.5 * dt * k2, control );
+  State<Scalar> k4 = motion_model( current_state + dt * k3, control );
 
   return current_state + ( dt / 6.0 ) * ( k1 + 2 * k2 + 2 * k3 + k4 );
 }
 
 // Horizon integration function
-inline StateTrajectory
-integrate_horizon( const State& initial_state, const ControlTrajectory& controls, double dt, const MotionModel& motion_model,
-                   const std::function<State( const State&, const Control&, double, const MotionModel& )>& single_step_integrator )
+template <typename Scalar = double>
+inline StateTrajectoryT<Scalar>
+integrate_horizon( const State<Scalar>& initial_state, const ControlTrajectoryT<Scalar>& controls, double dt,
+                   const MotionModel<Scalar>& motion_model,
+                   const std::function<State<Scalar>( const State<Scalar>&, const Control<Scalar>&, double,
+                                                     const MotionModel<Scalar>& )>& single_step_integrator )
 {
   // Initialize the state trajectory
-  StateTrajectory state_trajectory( initial_state.size(), controls.cols() + 1 );
+  StateTrajectoryT<Scalar> state_trajectory( initial_state.size(), controls.cols() + 1 );
   state_trajectory.col( 0 ) = initial_state;
 
   // Integrate step by step
-  State state = initial_state;
+  State<Scalar> state = initial_state;
   for( int i = 0; i < controls.cols(); ++i )
   {
     state                         = single_step_integrator( state, controls.col( i ), dt, motion_model );

--- a/include/multi_agent_solver/solvers/cgd.hpp
+++ b/include/multi_agent_solver/solvers/cgd.hpp
@@ -5,7 +5,6 @@
 #include <Eigen/Dense>
 
 #include "multi_agent_solver/constraint_helpers.hpp"
-#include "multi_agent_solver/finite_differences.hpp"
 #include "multi_agent_solver/integrator.hpp"
 #include "multi_agent_solver/line_search.hpp"
 #include "multi_agent_solver/ocp.hpp"
@@ -71,8 +70,9 @@ public:
         break;
       }
 
-      const ControlGradient gradients = finite_differences_gradient( problem.initial_state, controls, problem.dynamics,
-                                                                     problem.objective_function, problem.dt );
+      const ControlGradient gradients
+        = problem.trajectory_gradient( problem.initial_state, controls, problem.dynamics, problem.objective_function,
+                                       problem.dt );
 
       const double step_size = armijo_line_search( problem.initial_state, controls, gradients, problem.dynamics, problem.objective_function,
                                                    problem.dt, {} );

--- a/include/multi_agent_solver/solvers/osqp.hpp
+++ b/include/multi_agent_solver/solvers/osqp.hpp
@@ -282,7 +282,8 @@ private:
 
     for( int t = 0; t <= T; ++t )
     {
-      const Eigen::MatrixXd Q = p.cost_state_hessian( p.stage_cost, x.col( t ), u.col( std::min( t, T - 1 ) ), t );
+      const Eigen::MatrixXd Q
+        = p.cost_state_hessian( p.stage_cost, x.col( t ), u.col( std::min( t, T - 1 ) ), t );
       for( int i = 0; i < nx; ++i )
       {
         const int idx = t * nx + i;
@@ -312,10 +313,12 @@ private:
 
     qp_data.gradient.setZero();
     for( int t = 0; t <= T; ++t )
-      qp_data.gradient.segment( t * nx, nx ) = p.cost_state_gradient( p.stage_cost, x.col( t ), u.col( t ), t );
+      qp_data.gradient.segment( t * nx, nx )
+        = p.cost_state_gradient( p.stage_cost, x.col( t ), u.col( t ), t );
 
     for( int t = 0; t < T; ++t )
-      qp_data.gradient.segment( ( T + 1 ) * nx + t * nu, nu ) = p.cost_control_gradient( p.stage_cost, x.col( t ), u.col( t ), t );
+      qp_data.gradient.segment( ( T + 1 ) * nx + t * nu, nu )
+        = p.cost_control_gradient( p.stage_cost, x.col( t ), u.col( t ), t );
   }
 
   //--------------------------------------------------------------------//

--- a/include/multi_agent_solver/solvers/osqp_collocation.hpp
+++ b/include/multi_agent_solver/solvers/osqp_collocation.hpp
@@ -221,9 +221,11 @@ OSQPCollocation::assemble_values( const OCP& p, const StateTrajectory& X, const 
 {
   qp.g.setZero();
   for( int t = 1; t <= T; ++t )
-    qp.g.segment( id_state( t, 0, nx ), nx ) = p.cost_state_gradient( p.stage_cost, X.col( t ), U.col( std::min( t, T - 1 ) ), t );
+    qp.g.segment( id_state( t, 0, nx ), nx )
+      = p.cost_state_gradient( p.stage_cost, X.col( t ), U.col( std::min( t, T - 1 ) ), t );
   for( int t = 0; t < T; ++t )
-    qp.g.segment( id_control( t, nx, nu, T ), nu ) = p.cost_control_gradient( p.stage_cost, X.col( t ), U.col( t ), t );
+    qp.g.segment( id_control( t, nx, nu, T ), nu )
+      = p.cost_control_gradient( p.stage_cost, X.col( t ), U.col( t ), t );
 
   double*     h_val = qp.H.valuePtr();
   std::size_t kH    = 0;

--- a/include/multi_agent_solver/types.hpp
+++ b/include/multi_agent_solver/types.hpp
@@ -11,45 +11,64 @@ namespace mas
 {
 
 // Types defined for clarity in other functions
-using State             = Eigen::VectorXd;
-using StateDerivative   = Eigen::VectorXd;
-using Control           = Eigen::VectorXd;
-using ControlTrajectory = Eigen::MatrixXd;
-using StateTrajectory   = Eigen::MatrixXd;
+template <typename Scalar = double>
+using State = Eigen::Matrix<Scalar, Eigen::Dynamic, 1>;
+template <typename Scalar = double>
+using StateDerivative = Eigen::Matrix<Scalar, Eigen::Dynamic, 1>;
+template <typename Scalar = double>
+using Control = Eigen::Matrix<Scalar, Eigen::Dynamic, 1>;
+template <typename Scalar = double>
+using ControlTrajectoryT = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>;
+template <typename Scalar = double>
+using StateTrajectoryT = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>;
+using ControlTrajectory = ControlTrajectoryT<>;
+using StateTrajectory   = StateTrajectoryT<>;
 
 // Dynamics
-using MotionModel = std::function<StateDerivative( const State&, const Control& )>;
+template <typename Scalar = double>
+using MotionModel =
+  std::function<StateDerivative<Scalar>( const State<Scalar>&, const Control<Scalar>& )>;
 
 // Cost Function
 using ObjectiveFunction = std::function<double( const StateTrajectory&, const ControlTrajectory& )>;
 
 // A stage cost is evaluated on a single (state, control) pair.
-using StageCostFunction = std::function<double( const State&, const Control&, size_t time_idx )>;
+template <typename Scalar = double>
+using StageCostFunction = std::function<Scalar( const State<Scalar>&, const Control<Scalar>&, size_t time_idx )>;
 // A terminal cost is evaluated on the final state.
-using TerminalCostFunction = std::function<double( const State& )>;
+template <typename Scalar = double>
+using TerminalCostFunction = std::function<Scalar( const State<Scalar>& )>;
 
 
 // Constraints
 using ConstraintViolations        = Eigen::VectorXd;
-using ConstraintsFunction         = std::function<ConstraintViolations( const State&, const Control& )>;
+using ConstraintsFunction         = std::function<ConstraintViolations( const State<>&, const Control<> )>;
 using ConstraintsJacobian         = Eigen::MatrixXd;
-using ConstraintsJacobianFunction = std::function<ConstraintsJacobian( const State&, const Control& )>;
+using ConstraintsJacobianFunction = std::function<ConstraintsJacobian( const State<>&, const Control<> )>;
 
 
 // Derivative interfaces
-using DynamicsStateJacobian   = std::function<Eigen::MatrixXd( const MotionModel& dynamics, const State&, const Control& )>;
-using DynamicsControlJacobian = std::function<Eigen::MatrixXd( const MotionModel& dynamics, const State&, const Control& )>;
-using CostStateGradient       = std::function<Eigen::VectorXd( const StageCostFunction&, const State&, const Control&, size_t )>;
-using CostControlGradient     = std::function<Eigen::VectorXd( const StageCostFunction&, const State&, const Control&, size_t )>;
-using CostStateHessian        = std::function<Eigen::MatrixXd( const StageCostFunction&, const State&, const Control&, size_t )>;
-using CostControlHessian      = std::function<Eigen::MatrixXd( const StageCostFunction&, const State&, const Control&, size_t )>;
-using CostCrossTerm           = std::function<Eigen::MatrixXd( const StageCostFunction&, const State&, const Control&, size_t )>;
+using DynamicsStateJacobian
+  = std::function<Eigen::MatrixXd( const MotionModel<>& dynamics, const State<>&, const Control<>& )>;
+using DynamicsControlJacobian
+  = std::function<Eigen::MatrixXd( const MotionModel<>& dynamics, const State<>&, const Control<>& )>;
+using CostStateGradient
+  = std::function<Eigen::VectorXd( const StageCostFunction<>&, const State<>&, const Control<>&, size_t )>;
+using CostControlGradient
+  = std::function<Eigen::VectorXd( const StageCostFunction<>&, const State<>&, const Control<>&, size_t )>;
+using CostStateHessian
+  = std::function<Eigen::MatrixXd( const StageCostFunction<>&, const State<>&, const Control<>&, size_t )>;
+using CostControlHessian
+  = std::function<Eigen::MatrixXd( const StageCostFunction<>&, const State<>&, const Control<>&, size_t )>;
+using CostCrossTerm
+  = std::function<Eigen::MatrixXd( const StageCostFunction<>&, const State<>&, const Control<>&, size_t )>;
 using ControlGradient         = Eigen::MatrixXd;
 
 // GradientComputer interface
 using GradientComputer
-  = std::function<ControlGradient( const State& initial_state, const ControlTrajectory& controls, const MotionModel& dynamics,
-                                   const ObjectiveFunction& objective_function, double timestep )>;
+  = std::function<ControlGradient( const State<>& initial_state, const ControlTrajectory& controls,
+                                   const MotionModel<>& dynamics, const ObjectiveFunction& objective_function,
+                                   double timestep )>;
 using SolverParams = std::unordered_map<std::string, double>;
 
 // ANSI Escape Codes for Colors


### PR DESCRIPTION
## Summary
- Template state, control, motion model, and cost types on scalar to support autodiff
- Provide CppAD-based derivative helpers and centralize autodiff toggling in OCP
- Simplify solvers to use OCP-supplied derivatives without scattered preprocessor checks

## Testing
- `apt-get install -y libeigen3-dev`
- `apt-get install -y libosqp-dev` *(fails: Unable to locate package libosqp-dev)*
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "osqp")*


------
https://chatgpt.com/codex/tasks/task_e_68a4b553a17c832aa7ed6e7921682eb8