### PR TITLE
Add optional autodiff backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,7 @@ target_link_libraries(MultiAgentSolver INTERFACE
 )
 
 if(MAS_USE_AUTODIFF)
-  include(FetchContent)
-  FetchContent_Declare(autodiff
-    GIT_REPOSITORY https://github.com/autodiff/autodiff.git
-    GIT_TAG v1.0.1
-  )
-  FetchContent_MakeAvailable(autodiff)
+  find_package(autodiff REQUIRED CONFIG)
   target_link_libraries(MultiAgentSolver INTERFACE autodiff::autodiff)
   target_compile_definitions(MultiAgentSolver INTERFACE MAS_USE_AUTODIFF)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(BUILD_EXAMPLES "Build example executables" ON)
 option(BUILD_SHARED_LIBS "Build as shared library" OFF)
+option(MAS_USE_AUTODIFF "Enable autodifferentiation support" OFF)
 
 # Dependencies
 find_package(Eigen3 3.4 REQUIRED NO_MODULE)
@@ -27,6 +28,17 @@ target_link_libraries(MultiAgentSolver INTERFACE
   osqp::osqp
   OpenMP::OpenMP_CXX
 )
+
+if(MAS_USE_AUTODIFF)
+  include(FetchContent)
+  FetchContent_Declare(autodiff
+    GIT_REPOSITORY https://github.com/autodiff/autodiff.git
+    GIT_TAG v1.0.1
+  )
+  FetchContent_MakeAvailable(autodiff)
+  target_link_libraries(MultiAgentSolver INTERFACE autodiff::autodiff)
+  target_compile_definitions(MultiAgentSolver INTERFACE MAS_USE_AUTODIFF)
+endif()
 
 # Optional examples
 if(BUILD_EXAMPLES)

--- a/examples/multi_agent_single_track.cpp
+++ b/examples/multi_agent_single_track.cpp
@@ -10,6 +10,7 @@
 #include "multi_agent_solver/multi_agent_aggregator.hpp"
 #include "multi_agent_solver/ocp.hpp"
 #include "multi_agent_solver/solvers/solver.hpp"
+#include "multi_agent_solver/types.hpp"
 
 mas::OCP
 create_single_track_circular_ocp( double initial_theta, double track_radius, double target_velocity, int agent_id,
@@ -45,14 +46,14 @@ create_single_track_circular_ocp( double initial_theta, double track_radius, dou
     const double w_separation = 0.0;
 
     // Extract states
-    double x   = state( 0 );
-    double y   = state( 1 );
-    double psi = state( 2 );
-    double vx  = state( 3 );
+    double x   = to_double( state( 0 ) );
+    double y   = to_double( state( 1 ) );
+    double psi = to_double( state( 2 ) );
+    double vx  = to_double( state( 3 ) );
 
     // Extract controls
-    double delta = control( 0 );
-    double a_cmd = control( 1 );
+    double delta = to_double( control( 0 ) );
+    double a_cmd = to_double( control( 1 ) );
 
     // Compute deviation from circular path
     double distance_from_track = std::abs( std::sqrt( x * x + y * y ) - 20 );

--- a/examples/single_track_ocp.cpp
+++ b/examples/single_track_ocp.cpp
@@ -41,12 +41,12 @@ create_single_track_lane_following_ocp()
   // Stage cost function.
   problem.stage_cost = [=]( const State& state, const Control& control, size_t idx ) -> double {
     // Unpack state: we only use Y (index 1) and vx (index 3).
-    double y  = state( 1 );
-    double vx = state( 3 );
+    double y  = to_double( state( 1 ) );
+    double vx = to_double( state( 3 ) );
 
     // Unpack control: steering delta and acceleration.
-    double delta = control( 0 );
-    double a_cmd = control( 1 );
+    double delta = to_double( control( 0 ) );
+    double a_cmd = to_double( control( 1 ) );
 
     // Compute errors.
     double lane_error  = y;
@@ -64,8 +64,8 @@ create_single_track_lane_following_ocp()
   problem.cost_state_gradient = [=]( const StageCostFunction&, const State& state, const Control&, size_t time_idx ) -> Eigen::VectorXd {
     Eigen::VectorXd grad = Eigen::VectorXd::Zero( state.size() );
     // Only Y (index 1) and vx (index 3) appear in the cost.
-    grad( 1 ) = 2.0 * w_lane * state( 1 );
-    grad( 3 ) = 2.0 * w_speed * ( state( 3 ) - desired_velocity );
+    grad( 1 ) = 2.0 * w_lane * to_double( state( 1 ) );
+    grad( 3 ) = 2.0 * w_speed * ( to_double( state( 3 ) ) - desired_velocity );
     return grad;
   };
 
@@ -73,8 +73,8 @@ create_single_track_lane_following_ocp()
   problem.cost_control_gradient = [=]( const StageCostFunction&, const State&, const Control& control,
                                        size_t time_idx ) -> Eigen::VectorXd {
     Eigen::VectorXd grad = Eigen::VectorXd::Zero( control.size() );
-    grad( 0 )            = 2.0 * w_delta * control( 0 );
-    grad( 1 )            = 2.0 * w_acc * control( 1 );
+    grad( 0 )            = 2.0 * w_delta * to_double( control( 0 ) );
+    grad( 1 )            = 2.0 * w_acc * to_double( control( 1 ) );
     return grad;
   };
 

--- a/include/multi_agent_solver/autodiff.hpp
+++ b/include/multi_agent_solver/autodiff.hpp
@@ -32,6 +32,128 @@ autodiff_gradient( const State& initial_state, const ControlTrajectory& controls
 
   return Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>( g.data(), controls.rows(), controls.cols() );
 }
+
+inline Eigen::MatrixXd
+autodiff_dynamics_state_jacobian( const MotionModel& dynamics, const State& x, const Control& u )
+{
+  using autodiff::dual;
+  using VectorXdual = Eigen::Matrix<dual, Eigen::Dynamic, 1>;
+
+  VectorXdual x_ad = x;
+  VectorXdual u_ad = u;
+  VectorXdual y;
+
+  auto f = [&]( const VectorXdual& xv ) { return dynamics( xv, u_ad ); };
+  return autodiff::jacobian( f, autodiff::wrt( x_ad ), autodiff::at( x_ad ), y );
+}
+
+inline Eigen::MatrixXd
+autodiff_dynamics_control_jacobian( const MotionModel& dynamics, const State& x, const Control& u )
+{
+  using autodiff::dual;
+  using VectorXdual = Eigen::Matrix<dual, Eigen::Dynamic, 1>;
+
+  VectorXdual x_ad = x;
+  VectorXdual u_ad = u;
+  VectorXdual y;
+
+  auto f = [&]( const VectorXdual& uv ) { return dynamics( x_ad, uv ); };
+  return autodiff::jacobian( f, autodiff::wrt( u_ad ), autodiff::at( u_ad ), y );
+}
+
+inline Eigen::VectorXd
+autodiff_cost_state_gradient( const StageCostFunction& stage_cost, const State& x, const Control& u, size_t time_idx )
+{
+  using autodiff::dual;
+  using VectorXdual = Eigen::Matrix<dual, Eigen::Dynamic, 1>;
+
+  VectorXdual x_ad = x;
+  VectorXdual u_ad = u;
+  dual         y;
+  Eigen::VectorXd g;
+
+  auto f = [&]( const VectorXdual& xv ) -> dual { return stage_cost( xv, u_ad, time_idx ); };
+  autodiff::gradient( f, autodiff::wrt( x_ad ), autodiff::at( x_ad ), y, g );
+  return g;
+}
+
+inline Eigen::VectorXd
+autodiff_cost_control_gradient( const StageCostFunction& stage_cost, const State& x, const Control& u, size_t time_idx )
+{
+  using autodiff::dual;
+  using VectorXdual = Eigen::Matrix<dual, Eigen::Dynamic, 1>;
+
+  VectorXdual x_ad = x;
+  VectorXdual u_ad = u;
+  dual         y;
+  Eigen::VectorXd g;
+
+  auto f = [&]( const VectorXdual& uv ) -> dual { return stage_cost( x_ad, uv, time_idx ); };
+  autodiff::gradient( f, autodiff::wrt( u_ad ), autodiff::at( u_ad ), y, g );
+  return g;
+}
+
+inline Eigen::MatrixXd
+autodiff_cost_state_hessian( const StageCostFunction& stage_cost, const State& x, const Control& u, size_t time_idx )
+{
+  using autodiff::dual;
+  using VectorXdual = Eigen::Matrix<dual, Eigen::Dynamic, 1>;
+
+  VectorXdual x_ad = x;
+
+  auto grad_x = [&]( VectorXdual xv ) -> VectorXdual {
+    dual       y;
+    VectorXdual g;
+    auto f = [&]( const VectorXdual& xin ) -> dual { return stage_cost( xin, u, time_idx ); };
+    autodiff::gradient( f, autodiff::wrt( xv ), autodiff::at( xv ), y, g );
+    return g;
+  };
+
+  VectorXdual g_out;
+  return autodiff::jacobian( grad_x, autodiff::wrt( x_ad ), autodiff::at( x_ad ), g_out );
+}
+
+inline Eigen::MatrixXd
+autodiff_cost_control_hessian( const StageCostFunction& stage_cost, const State& x, const Control& u, size_t time_idx )
+{
+  using autodiff::dual;
+  using VectorXdual = Eigen::Matrix<dual, Eigen::Dynamic, 1>;
+
+  VectorXdual u_ad = u;
+
+  auto grad_u = [&]( VectorXdual uv ) -> VectorXdual {
+    dual       y;
+    VectorXdual g;
+    auto f = [&]( const VectorXdual& uin ) -> dual { return stage_cost( x, uin, time_idx ); };
+    autodiff::gradient( f, autodiff::wrt( uv ), autodiff::at( uv ), y, g );
+    return g;
+  };
+
+  VectorXdual g_out;
+  return autodiff::jacobian( grad_u, autodiff::wrt( u_ad ), autodiff::at( u_ad ), g_out );
+}
+
+inline Eigen::MatrixXd
+autodiff_cost_cross_term( const StageCostFunction& stage_cost, const State& x, const Control& u, size_t time_idx )
+{
+  using autodiff::dual;
+  using VectorXdual = Eigen::Matrix<dual, Eigen::Dynamic, 1>;
+
+  VectorXdual x_ad = x;
+  VectorXdual u_ad = u;
+
+  auto grad_u_given_x = [&]( VectorXdual xv ) -> VectorXdual {
+    dual       y;
+    VectorXdual g;
+    auto f = [&]( const VectorXdual& uv ) -> dual { return stage_cost( xv, uv, time_idx ); };
+    autodiff::gradient( f, autodiff::wrt( u_ad ), autodiff::at( u_ad ), y, g );
+    return g;
+  };
+
+  VectorXdual g_out;
+  // Jacobian of grad_u w.r.t x gives matrix of size (m x n)
+  return autodiff::jacobian( grad_u_given_x, autodiff::wrt( x_ad ), autodiff::at( x_ad ), g_out );
+}
 } // namespace mas
 
 #endif // MAS_USE_AUTODIFF

--- a/include/multi_agent_solver/autodiff.hpp
+++ b/include/multi_agent_solver/autodiff.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#ifdef MAS_USE_AUTODIFF
+
+  #include "multi_agent_solver/integrator.hpp"
+  #include "multi_agent_solver/types.hpp"
+  #include <autodiff/forward/dual.hpp>
+  #include <autodiff/forward/dual/eigen.hpp>
+
+namespace mas
+{
+inline ControlGradient
+autodiff_gradient( const State& initial_state, const ControlTrajectory& controls, const MotionModel& dynamics,
+                   const ObjectiveFunction& objective_function, double dt )
+{
+  using autodiff::dual;
+  using autodiff::VectorXdual;
+  using MatrixXdual = Eigen::Matrix<dual, Eigen::Dynamic, Eigen::Dynamic>;
+
+  // Flatten controls into a single vector for autodiff
+  VectorXdual u = Eigen::Map<const VectorXdual>( controls.data(), controls.size() );
+
+  auto f = [&]( const VectorXdual& uv ) -> dual {
+    MatrixXdual     U = Eigen::Map<const MatrixXdual>( uv.data(), controls.rows(), controls.cols() );
+    StateTrajectory X = integrate_horizon( initial_state, U, dt, dynamics, integrate_rk4 );
+    return objective_function( X, U );
+  };
+
+  dual            y;
+  Eigen::VectorXd g;
+  autodiff::gradient( f, autodiff::wrt( u ), autodiff::at( u ), y, g );
+
+  return Eigen::Map<Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>>( g.data(), controls.rows(), controls.cols() );
+}
+} // namespace mas
+
+#endif // MAS_USE_AUTODIFF

--- a/include/multi_agent_solver/finite_differences.hpp
+++ b/include/multi_agent_solver/finite_differences.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <cmath>
 
 #include <Eigen/Dense>
 
@@ -29,7 +30,8 @@ finite_differences_gradient( const State& initial_state, const ControlTrajectory
   {
     for( int i = 0; i < controls.rows(); ++i )
     {
-      double epsilon = std::max( 1e-6, 1e-8 * std::abs( controls( i, t ) ) );
+      // Use raw double value for epsilon to avoid issues with autodiff types
+      double epsilon = std::max( 1e-6, 1e-8 * std::abs( to_double( controls( i, t ) ) ) );
 
       controls_plus                    = controls;
       controls_plus( i, t )           += epsilon;

--- a/include/multi_agent_solver/line_search.hpp
+++ b/include/multi_agent_solver/line_search.hpp
@@ -38,7 +38,7 @@ armijo_line_search( const State& initial_state, const ControlTrajectory& control
   double c1                = get_parameter( parameters, "c1", 1e-6 );
 
   double alpha    = initial_step_size;
-  double cost_ref = objective_function( integrate_horizon( initial_state, controls, dt, dynamics, integrate_rk4 ), controls );
+  double cost_ref = to_double( objective_function( integrate_horizon( initial_state, controls, dt, dynamics, integrate_rk4 ), controls ) );
 
   // The search direction is the negative gradient, so grad^T * (-grad)
   // should be negative. The Armijo condition expects f(x + alpha p)
@@ -52,7 +52,7 @@ armijo_line_search( const State& initial_state, const ControlTrajectory& control
     // Compute trial controls and cost
     ControlTrajectory trial_controls   = controls - alpha * gradients;
     StateTrajectory   trial_trajectory = integrate_horizon( initial_state, trial_controls, dt, dynamics, integrate_rk4 );
-    double            trial_cost       = objective_function( trial_trajectory, trial_controls );
+    double            trial_cost       = to_double( objective_function( trial_trajectory, trial_controls ) );
 
     // Check Armijo condition. directional_derivative is negative, so the
     // right-hand side is less than cost_ref when a descent direction is
@@ -86,14 +86,14 @@ backtracking_line_search( const State& initial_state, const ControlTrajectory& c
   double beta              = get_parameter( parameters, "beta", 0.5 );
 
   double alpha    = initial_step_size;
-  double cost_ref = objective_function( integrate_horizon( initial_state, controls, dt, dynamics, integrate_rk4 ), controls );
+  double cost_ref = to_double( objective_function( integrate_horizon( initial_state, controls, dt, dynamics, integrate_rk4 ), controls ) );
 
   while( true )
   {
     // Compute trial controls and cost
     ControlTrajectory trial_controls   = controls - alpha * gradients;
     StateTrajectory   trial_trajectory = integrate_horizon( initial_state, trial_controls, dt, dynamics, integrate_rk4 );
-    double            trial_cost       = objective_function( trial_trajectory, trial_controls );
+    double            trial_cost       = to_double( objective_function( trial_trajectory, trial_controls ) );
 
     // Check if cost decreased
     if( trial_cost < cost_ref )
@@ -123,4 +123,4 @@ constant_line_search( const State& /*initial_state*/, const ControlTrajectory& /
 
   return get_parameter( parameters, "step_size", 0.1 );
 }
-}
+} // namespace mas

--- a/include/multi_agent_solver/multi_agent_aggregator.hpp
+++ b/include/multi_agent_solver/multi_agent_aggregator.hpp
@@ -396,8 +396,8 @@ private:
   void
   setup_objective_function( OCP& global_ocp ) const
   {
-    global_ocp.stage_cost = [this]( const State& full_x, const Control& full_u, size_t time_index ) -> double {
-      double total_cost = 0.0;
+    global_ocp.stage_cost = [this]( const State& full_x, const Control& full_u, size_t time_index ) -> Scalar {
+      Scalar total_cost = 0.0;
 
       if( !use_only_global_cost_and_constraints )
       {
@@ -418,8 +418,8 @@ private:
       return total_cost;
     };
 
-    global_ocp.terminal_cost = [this]( const State& full_x ) -> double {
-      double total_cost = 0.0;
+    global_ocp.terminal_cost = [this]( const State& full_x ) -> Scalar {
+      Scalar total_cost = 0.0;
 
       if( !use_only_global_cost_and_constraints )
       {

--- a/include/multi_agent_solver/multi_agent_solver.hpp
+++ b/include/multi_agent_solver/multi_agent_solver.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include "multi_agent_solver/constraint_helpers.hpp"
-#include "multi_agent_solver/finite_differences.hpp"
 #include "multi_agent_solver/integrator.hpp"
 #include "multi_agent_solver/line_search.hpp"
 #include "multi_agent_solver/models/single_track_model.hpp"

--- a/include/multi_agent_solver/ocp.hpp
+++ b/include/multi_agent_solver/ocp.hpp
@@ -7,6 +7,9 @@
 
 #include "multi_agent_solver/finite_differences.hpp"
 #include "multi_agent_solver/types.hpp"
+#ifdef MAS_USE_AUTODIFF
+  #include "multi_agent_solver/autodiff.hpp"
+#endif
 
 namespace mas
 {
@@ -108,7 +111,23 @@ struct OCP
     best_controls = initial_controls;
 
 
-    // use finite differences when derivatives are not specified
+    // Assign derivative routines if not provided
+#ifdef MAS_USE_AUTODIFF
+    if( !dynamics_state_jacobian )
+      dynamics_state_jacobian = autodiff_dynamics_state_jacobian;
+    if( !dynamics_control_jacobian )
+      dynamics_control_jacobian = autodiff_dynamics_control_jacobian;
+    if( !cost_state_gradient )
+      cost_state_gradient = autodiff_cost_state_gradient;
+    if( !cost_control_gradient )
+      cost_control_gradient = autodiff_cost_control_gradient;
+    if( !cost_state_hessian )
+      cost_state_hessian = autodiff_cost_state_hessian;
+    if( !cost_control_hessian )
+      cost_control_hessian = autodiff_cost_control_hessian;
+    if( !cost_cross_term )
+      cost_cross_term = autodiff_cost_cross_term;
+#else
     if( !dynamics_state_jacobian )
       dynamics_state_jacobian = compute_dynamics_state_jacobian;
     if( !dynamics_control_jacobian )
@@ -123,6 +142,7 @@ struct OCP
       cost_control_hessian = compute_cost_control_hessian;
     if( !cost_cross_term )
       cost_cross_term = compute_cost_cross_term;
+#endif
 
     if( !objective_function && stage_cost && terminal_cost )
     {

--- a/include/multi_agent_solver/ocp.hpp
+++ b/include/multi_agent_solver/ocp.hpp
@@ -21,9 +21,9 @@ compute_trajectory_cost( const StateTrajectory& X, const ControlTrajectory& U, c
   double cost = 0.0;
   for( int t = 0; t < T; ++t )
   {
-    cost += stage_cost( X.col( t ), U.col( t ), t );
+    cost += to_double( stage_cost( X.col( t ), U.col( t ), t ) );
   }
-  cost += terminal_cost( X.col( Tp1 - 1 ) );
+  cost += to_double( terminal_cost( X.col( Tp1 - 1 ) ) );
   return cost;
 }
 
@@ -84,7 +84,7 @@ struct OCP
     best_states   = initial_states;
     best_controls = initial_controls;
 
-    best_cost = objective_function( initial_states, initial_controls );
+    best_cost = to_double( objective_function( initial_states, initial_controls ) );
   }
 
   void
@@ -129,11 +129,11 @@ struct OCP
       auto stage_cost_local    = stage_cost;
       auto terminal_cost_local = terminal_cost;
       objective_function       = [stage_cost_local, terminal_cost_local]( const StateTrajectory&   states,
-                                                                    const ControlTrajectory& controls ) -> double {
+                                                                    const ControlTrajectory& controls ) -> Scalar {
         return compute_trajectory_cost( states, controls, stage_cost_local, terminal_cost_local );
       };
     }
-    best_cost = objective_function( initial_states, initial_controls );
+    best_cost = to_double( objective_function( initial_states, initial_controls ) );
   }
 
   // Verify that the problem's dimensions and outputs are consistent
@@ -172,7 +172,7 @@ struct OCP
     assert( dynamics_output.size() == state_dim && "Dynamics output size mismatch" );
 
     // Test objective function
-    double cost = objective_function( best_states, best_controls );
+    double cost = to_double( objective_function( best_states, best_controls ) );
 
     // If constraints exist, test them
     if( inequality_constraints )

--- a/include/multi_agent_solver/solvers/cgd.hpp
+++ b/include/multi_agent_solver/solvers/cgd.hpp
@@ -5,7 +5,11 @@
 #include <Eigen/Dense>
 
 #include "multi_agent_solver/constraint_helpers.hpp"
-#include "multi_agent_solver/finite_differences.hpp"
+#ifdef MAS_USE_AUTODIFF
+  #include "multi_agent_solver/autodiff.hpp"
+#else
+  #include "multi_agent_solver/finite_differences.hpp"
+#endif
 #include "multi_agent_solver/integrator.hpp"
 #include "multi_agent_solver/line_search.hpp"
 #include "multi_agent_solver/ocp.hpp"
@@ -71,8 +75,13 @@ public:
         break;
       }
 
+#ifdef MAS_USE_AUTODIFF
+      const ControlGradient gradients = autodiff_gradient( problem.initial_state, controls, problem.dynamics, problem.objective_function,
+                                                           problem.dt );
+#else
       const ControlGradient gradients = finite_differences_gradient( problem.initial_state, controls, problem.dynamics,
                                                                      problem.objective_function, problem.dt );
+#endif
 
       const double step_size = armijo_line_search( problem.initial_state, controls, gradients, problem.dynamics, problem.objective_function,
                                                    problem.dt, {} );

--- a/include/multi_agent_solver/solvers/ilqr.hpp
+++ b/include/multi_agent_solver/solvers/ilqr.hpp
@@ -138,8 +138,9 @@ public:
       {
         for( int t = 0; t < T; ++t )
         {
-          const Eigen::VectorXd dx = x_trial.col( t ) - x.col( t );
-          u_trial.col( t )         = u.col( t ) + alpha * k[t] + k_matrix[t] * dx;
+          const Eigen::VectorXd dx
+            = ( x_trial.col( t ) - x.col( t ) ).unaryExpr( []( const Scalar& s ) { return to_double( s ); } );
+          u_trial.col( t ) = u.col( t ) + alpha * k[t] + k_matrix[t] * dx;
 
           if( problem.input_lower_bounds && problem.input_upper_bounds )
             clamp_controls( u_trial, *problem.input_lower_bounds, *problem.input_upper_bounds );

--- a/include/multi_agent_solver/solvers/ilqr.hpp
+++ b/include/multi_agent_solver/solvers/ilqr.hpp
@@ -61,7 +61,7 @@ public:
 
     // ---------- initial rollout & cost ----------------------------------
     x    = integrate_horizon( problem.initial_state, u, dt, problem.dynamics, integrate_rk4 );
-    cost = problem.objective_function( x, u );
+    cost = to_double( problem.objective_function( x, u ) );
     if( debug )
       std::cerr << "2 initial cost: " << cost << '\n';
 
@@ -147,7 +147,7 @@ public:
           x_trial.col( t + 1 ) = integrate_rk4( x_trial.col( t ), u_trial.col( t ), dt, problem.dynamics );
         }
 
-        const double new_cost = problem.objective_function( x_trial, u_trial );
+        const double new_cost = to_double( problem.objective_function( x_trial, u_trial ) );
         if( new_cost < best_cost )
         {
           best_cost = new_cost;

--- a/include/multi_agent_solver/solvers/osqp.hpp
+++ b/include/multi_agent_solver/solvers/osqp.hpp
@@ -166,9 +166,11 @@ public:
         u_candidate.col( t ) = solution.segment( Ns * nx + t * nu, nu );
 
       d_u = controls - u_candidate;
+      ControlGradient d_u_double
+        = d_u.unaryExpr( []( const Scalar& s ) { return to_double( s ); } );
 
-      const double alpha = armijo_line_search( problem.initial_state, controls, d_u, problem.dynamics, problem.objective_function,
-                                               problem.dt, ls_parameters );
+      const double alpha = armijo_line_search( problem.initial_state, controls, d_u_double, problem.dynamics,
+                                               problem.objective_function, problem.dt, ls_parameters );
 
       u_new                 = controls - alpha * d_u;
       states_new            = integrate_horizon( problem.initial_state, u_new, problem.dt, problem.dynamics, integrate_rk4 );
@@ -381,8 +383,10 @@ private:
       for( int i = 0; i < nx; ++i )
       {
         const int idx     = sb_off + t * nx + i;
-        qp_data.lb( idx ) = p.state_lower_bounds ? ( *p.state_lower_bounds )( i ) : -OsqpEigen::INFTY;
-        qp_data.ub( idx ) = p.state_upper_bounds ? ( *p.state_upper_bounds )( i ) : OsqpEigen::INFTY;
+        qp_data.lb( idx )
+          = p.state_lower_bounds ? to_double( ( *p.state_lower_bounds )( i ) ) : -OsqpEigen::INFTY;
+        qp_data.ub( idx )
+          = p.state_upper_bounds ? to_double( ( *p.state_upper_bounds )( i ) ) : OsqpEigen::INFTY;
       }
 
 
@@ -391,8 +395,10 @@ private:
       for( int i = 0; i < nu; ++i )
       {
         const int idx     = cb_off + t * nu + i;
-        qp_data.lb( idx ) = p.input_lower_bounds ? ( *p.input_lower_bounds )( i ) : -OsqpEigen::INFTY;
-        qp_data.ub( idx ) = p.input_upper_bounds ? ( *p.input_upper_bounds )( i ) : OsqpEigen::INFTY;
+        qp_data.lb( idx )
+          = p.input_lower_bounds ? to_double( ( *p.input_lower_bounds )( i ) ) : -OsqpEigen::INFTY;
+        qp_data.ub( idx )
+          = p.input_upper_bounds ? to_double( ( *p.input_upper_bounds )( i ) ) : OsqpEigen::INFTY;
       }
   }
 

--- a/include/multi_agent_solver/solvers/osqp.hpp
+++ b/include/multi_agent_solver/solvers/osqp.hpp
@@ -80,7 +80,7 @@ public:
 
 
     states = integrate_horizon( problem.initial_state, controls, problem.dt, problem.dynamics, integrate_rk4 );
-    cost   = problem.objective_function( states, controls );
+    cost   = to_double( problem.objective_function( states, controls ) );
 
 
     double reg = 0.0;
@@ -172,7 +172,7 @@ public:
 
       u_new                 = controls - alpha * d_u;
       states_new            = integrate_horizon( problem.initial_state, u_new, problem.dt, problem.dynamics, integrate_rk4 );
-      const double cost_new = problem.objective_function( states_new, u_new );
+      const double cost_new = to_double( problem.objective_function( states_new, u_new ) );
 
       if( std::abs( cost - cost_new ) < tolerance )
       {

--- a/include/multi_agent_solver/solvers/osqp_collocation.hpp
+++ b/include/multi_agent_solver/solvers/osqp_collocation.hpp
@@ -256,11 +256,10 @@ OSQPCollocation::assemble_values( const OCP& p, const StateTrajectory& X, const 
 
   for( int t = 1; t <= T; ++t )
   {
-    const auto x = X.col( t );
-    const auto u = U.col( std::min( t, T - 1 ) );
-    bool       recompute = !use_cache || !cache_valid ||
-                           ( x - X_prev.col( t ) ).norm() > cache_eps ||
-                           ( u - U_prev.col( std::min( t, T - 1 ) ) ).norm() > cache_eps;
+    const auto x         = X.col( t );
+    const auto u         = U.col( std::min( t, T - 1 ) );
+    bool       recompute = !use_cache || !cache_valid || ( x - X_prev.col( t ) ).norm() > cache_eps
+                  || ( u - U_prev.col( std::min( t, T - 1 ) ) ).norm() > cache_eps;
 
     if( recompute )
     {
@@ -284,11 +283,9 @@ OSQPCollocation::assemble_values( const OCP& p, const StateTrajectory& X, const 
 
   for( int t = 0; t < T; ++t )
   {
-    const auto x = X.col( t );
-    const auto u = U.col( t );
-    bool       recompute = !use_cache || !cache_valid ||
-                           ( x - X_prev.col( t ) ).norm() > cache_eps ||
-                           ( u - U_prev.col( t ) ).norm() > cache_eps;
+    const auto x   = X.col( t );
+    const auto u   = U.col( t );
+    bool recompute = !use_cache || !cache_valid || ( x - X_prev.col( t ) ).norm() > cache_eps || ( u - U_prev.col( t ) ).norm() > cache_eps;
 
     if( recompute )
     {
@@ -316,11 +313,10 @@ OSQPCollocation::assemble_values( const OCP& p, const StateTrajectory& X, const 
   /* pre-compute dynamics Jacobians where needed ---------------- */
   for( int t = 0; t <= T; ++t )
   {
-    const auto x = X.col( t );
-    const auto u = U.col( std::min( t, T - 1 ) );
-    bool       recompute = !use_cache || !cache_valid ||
-                           ( x - X_prev.col( t ) ).norm() > cache_eps ||
-                           ( u - U_prev.col( std::min( t, T - 1 ) ) ).norm() > cache_eps;
+    const auto x         = X.col( t );
+    const auto u         = U.col( std::min( t, T - 1 ) );
+    bool       recompute = !use_cache || !cache_valid || ( x - X_prev.col( t ) ).norm() > cache_eps
+                  || ( u - U_prev.col( std::min( t, T - 1 ) ) ).norm() > cache_eps;
 
     if( recompute )
     {
@@ -475,7 +471,7 @@ OSQPCollocation::solve( OCP& problem )
     }
   }
 
-  problem.best_cost = problem.objective_function( X, U );
+  problem.best_cost = to_double( problem.objective_function( X, U ) );
 
   if( debug )
   {

--- a/scripts/setup_dependencies.sh
+++ b/scripts/setup_dependencies.sh
@@ -27,4 +27,17 @@ make install
 cd /
 rm -rf /tmp/osqp-eigen
 
-echo "✅ OSQP installed successfully."
+echo "🔽 Cloning autodiff repository..."
+git clone https://github.com/autodiff/autodiff.git /tmp/autodiff
+cd /tmp/autodiff
+mkdir build && cd build
+cmake -G "Unix Makefiles" .. \
+    -DAUTODIFF_BUILD_TESTS=OFF \
+    -DAUTODIFF_BUILD_PYTHON=OFF \
+    -DAUTODIFF_BUILD_EXAMPLES=OFF \
+    -DAUTODIFF_BUILD_DOCS=OFF
+cmake --build . --target install
+cd /
+rm -rf /tmp/autodiff
+
+echo "✅ Dependencies installed successfully."


### PR DESCRIPTION
## Summary
- add MAS_USE_AUTODIFF CMake option and fetch autodiff library when enabled
- introduce Scalar alias and helper in types.hpp to support autodiff numbers
- provide autodiff-based gradient computation and integrate it with CGD solver

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "osqp")*

------
https://chatgpt.com/codex/tasks/task_e_68a5a2bceb80832ab1135a4012828d0b