### PR TITLE
Fix iLQR value update and example Hessian dimension

### DIFF
--- a/examples/single_track_ocp.cpp
+++ b/examples/single_track_ocp.cpp
@@ -79,8 +79,8 @@ create_single_track_lane_following_ocp()
   };
 
   // Hessian with respect to state.
-  problem.cost_state_hessian = [=]( const StageCostFunction&, const State&, const Control&, size_t time_idx ) -> Eigen::MatrixXd {
-    Eigen::MatrixXd H = Eigen::MatrixXd::Zero( 6, 6 );
+  problem.cost_state_hessian = [=]( const StageCostFunction&, const State& state, const Control&, size_t ) -> Eigen::MatrixXd {
+    Eigen::MatrixXd H = Eigen::MatrixXd::Zero( state.size(), state.size() );
     H( 1, 1 )         = 2.0 * w_lane;
     H( 3, 3 )         = 2.0 * w_speed;
     return H;

--- a/include/multi_agent_solver/solvers/ilqr.hpp
+++ b/include/multi_agent_solver/solvers/ilqr.hpp
@@ -118,9 +118,16 @@ public:
         k_matrix[t] = -q_uu_inv_step[t] * q_ux_step[t];
 
         // Value function update ------------------------------------------
-        v_x  = q_x_step[t] + k_matrix[t].transpose() * ( q_uu_step[t] * k[t] + q_u_step[t] );
-        v_xx = q_xx_step[t] + k_matrix[t].transpose() * ( q_uu_step[t] * k_matrix[t] + q_ux_step[t] );
-        v_xx = 0.5 * ( v_xx + v_xx.transpose() ); // symmetrise
+        // V_x = Q_x + K^T Q_u + Q_{ux}^T k + K^T Q_{uu} k
+        v_x = q_x_step[t] + k_matrix[t].transpose() * q_u_step[t] + q_ux_step[t].transpose() * k[t]
+            + k_matrix[t].transpose() * q_uu_step[t] * k[t];
+
+        // V_xx = Q_xx + K^T Q_{ux} + Q_{ux}^T K + K^T Q_{uu} K
+        v_xx = q_xx_step[t] + k_matrix[t].transpose() * q_ux_step[t] + q_ux_step[t].transpose() * k_matrix[t]
+             + k_matrix[t].transpose() * q_uu_step[t] * k_matrix[t];
+
+        // Ensure symmetry of V_xx numerically
+        v_xx = 0.5 * ( v_xx + v_xx.transpose() );
       }
 
       //---------------------- forward pass ------------------------------//


### PR DESCRIPTION
## Summary
- Correct iLQR backward-pass update to include missing cross-term contributions
- Fix single_track_ocp example state Hessian to match state dimension

## Testing
- `./scripts/build.sh Release`
- `./build/release/single_track_ocp`


------
https://chatgpt.com/codex/tasks/task_e_68a5ebb27a54832a948e6b53b996ebb9