### PR TITLE
Add configurable example runners and solver comparison script

### DIFF
--- a/examples/example_utils.hpp
+++ b/examples/example_utils.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <algorithm>
+#include <cctype>
+#include <ostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "multi_agent_solver/solvers/solver.hpp"
+#include "multi_agent_solver/strategies/strategy.hpp"
+
+namespace examples
+{
+
+inline std::string
+normalize_key( std::string value )
+{
+  std::string result;
+  result.reserve( value.size() );
+  for( char ch : value )
+  {
+    if( std::isalnum( static_cast<unsigned char>( ch ) ) )
+      result.push_back( static_cast<char>( std::tolower( static_cast<unsigned char>( ch ) ) ) );
+  }
+  return result;
+}
+
+inline std::string
+canonical_solver_name( const std::string& name )
+{
+  const std::string key = normalize_key( name );
+  if( key == "ilqr" )
+    return "ilqr";
+  if( key == "cgd" )
+    return "cgd";
+#ifdef MAS_HAVE_OSQP
+  if( key == "osqp" )
+    return "osqp";
+  if( key == "osqpcollocation" )
+    return "osqp_collocation";
+#endif
+  throw std::invalid_argument( "Unknown solver '" + name + "'." );
+}
+
+inline std::string
+canonical_strategy_name( const std::string& name )
+{
+  const std::string key = normalize_key( name );
+  if( key == "centralized" || key == "centralised" )
+    return "centralized";
+  if( key == "sequential" || key == "sequentialnash" )
+    return "sequential";
+  if( key == "linesearch" || key == "linesearchnash" )
+    return "linesearch";
+  if( key == "trustregion" || key == "trustregionnash" )
+    return "trustregion";
+  throw std::invalid_argument( "Unknown strategy '" + name + "'." );
+}
+
+inline std::vector<std::string>
+available_solver_names()
+{
+  std::vector<std::string> names{ "ilqr", "cgd" };
+#ifdef MAS_HAVE_OSQP
+  names.push_back( "osqp" );
+  names.push_back( "osqp_collocation" );
+#endif
+  return names;
+}
+
+inline mas::Solver
+make_solver( const std::string& name )
+{
+  const std::string canonical = canonical_solver_name( name );
+  if( canonical == "ilqr" )
+    return mas::Solver{ std::in_place_type<mas::iLQR> };
+  if( canonical == "cgd" )
+    return mas::Solver{ std::in_place_type<mas::CGD> };
+#ifdef MAS_HAVE_OSQP
+  if( canonical == "osqp" )
+    return mas::Solver{ std::in_place_type<mas::OSQP> };
+  if( canonical == "osqp_collocation" )
+    return mas::Solver{ std::in_place_type<mas::OSQPCollocation> };
+#endif
+  throw std::invalid_argument( "Unknown solver '" + name + "'." );
+}
+
+inline mas::Strategy
+make_strategy( const std::string& name, mas::Solver solver, const mas::SolverParams& params, int max_outer )
+{
+  const std::string canonical = canonical_strategy_name( name );
+  if( canonical == "centralized" )
+  {
+    mas::set_params( solver, params );
+    return mas::Strategy{ mas::CentralizedStrategy{ std::move( solver ) } };
+  }
+  if( canonical == "sequential" )
+    return mas::Strategy{ mas::SequentialNashStrategy{ max_outer, std::move( solver ), params } };
+  if( canonical == "linesearch" )
+    return mas::Strategy{ mas::LineSearchNashStrategy{ max_outer, std::move( solver ), params } };
+  if( canonical == "trustregion" )
+    return mas::Strategy{ mas::TrustRegionNashStrategy{ max_outer, std::move( solver ), params } };
+  throw std::invalid_argument( "Unknown strategy '" + name + "'." );
+}
+
+inline void
+print_available( std::ostream& os )
+{
+  const auto solvers = available_solver_names();
+  os << "Available solvers:";
+  for( const auto& solver : solvers )
+    os << ' ' << solver;
+  os << '\n';
+  os << "Available strategies: centralized, sequential, linesearch, trustregion\n";
+}
+
+} // namespace examples

--- a/examples/multi_agent_lqr.cpp
+++ b/examples/multi_agent_lqr.cpp
@@ -1,4 +1,6 @@
+#include <charconv>
 #include <chrono>
+#include <system_error>
 #include <iomanip>
 #include <iostream>
 #include <memory>
@@ -58,14 +60,13 @@ namespace
 int
 parse_int( const std::string& label, const std::string& value )
 {
-  try
-  {
-    return std::stoi( value );
-  }
-  catch( const std::exception& )
-  {
+  int result = 0;
+  const char* begin = value.data();
+  const char* end   = begin + value.size();
+  const auto   [ptr, ec] = std::from_chars( begin, end, result );
+  if( ec != std::errc() || ptr != end )
     throw std::invalid_argument( "Invalid value for " + label + ": '" + value + "'" );
-  }
+  return result;
 }
 
 Options

--- a/examples/multi_agent_lqr.cpp
+++ b/examples/multi_agent_lqr.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <charconv>
 #include <chrono>
 #include <system_error>
@@ -77,6 +78,12 @@ parse_options( int argc, char** argv )
   for( int i = 1; i < argc; ++i )
   {
     std::string arg = argv[i];
+    if( arg.rfind( "--", 0 ) == 0 )
+    {
+      const auto eq_pos = arg.find( '=' );
+      const auto end    = eq_pos == std::string::npos ? arg.size() : eq_pos;
+      std::replace( arg.begin() + 2, arg.begin() + static_cast<std::ptrdiff_t>( end ), '_', '-' );
+    }
     auto        match_with_value = [&]( const std::string& name, std::string& out ) {
       const std::string prefix = name + "=";
       if( arg == name )

--- a/examples/multi_agent_lqr.cpp
+++ b/examples/multi_agent_lqr.cpp
@@ -1,9 +1,9 @@
 #include <chrono>
+#include <iomanip>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <string>
-#include <tuple>
-#include <vector>
 
 #include "Eigen/Dense"
 
@@ -12,6 +12,8 @@
 #include "multi_agent_solver/solvers/solver.hpp"
 #include "multi_agent_solver/strategies/strategy.hpp"
 #include "multi_agent_solver/types.hpp"
+
+#include "example_utils.hpp"
 
 /*──────────────── create simple LQR OCP (unchanged) ───────────────*/
 mas::OCP
@@ -41,123 +43,155 @@ create_linear_lqr_ocp( int n_x, int n_u, double dt, int T )
   return ocp;
 }
 
-struct Result
+struct Options
 {
-  std::string name;
-  double      cost;
-  double      time_ms;
+  bool        show_help   = false;
+  int         agents      = 10;
+  int         max_outer   = 10;
+  std::string solver      = "ilqr";
+  std::string strategy    = "centralized";
 };
+
+namespace
+{
+
+int
+parse_int( const std::string& label, const std::string& value )
+{
+  try
+  {
+    return std::stoi( value );
+  }
+  catch( const std::exception& )
+  {
+    throw std::invalid_argument( "Invalid value for " + label + ": '" + value + "'" );
+  }
+}
+
+Options
+parse_options( int argc, char** argv )
+{
+  Options options;
+  bool    positional_agents = false;
+  for( int i = 1; i < argc; ++i )
+  {
+    std::string arg = argv[i];
+    auto        match_with_value = [&]( const std::string& name, std::string& out ) {
+      const std::string prefix = name + "=";
+      if( arg == name )
+      {
+        if( i + 1 >= argc )
+          throw std::invalid_argument( "Missing value for option '" + name + "'" );
+        out = argv[++i];
+        return true;
+      }
+      if( arg.rfind( prefix, 0 ) == 0 )
+      {
+        out = arg.substr( prefix.size() );
+        return true;
+      }
+      return false;
+    };
+
+    if( arg == "--help" || arg == "-h" )
+    {
+      options.show_help = true;
+      continue;
+    }
+
+    std::string value;
+    if( match_with_value( "--agents", value ) )
+    {
+      options.agents = parse_int( "--agents", value );
+    }
+    else if( match_with_value( "--solver", value ) )
+    {
+      options.solver = value;
+    }
+    else if( match_with_value( "--strategy", value ) )
+    {
+      options.strategy = value;
+    }
+    else if( match_with_value( "--max-outer", value ) )
+    {
+      options.max_outer = parse_int( "--max-outer", value );
+    }
+    else if( !arg.empty() && arg.front() != '-' && !positional_agents )
+    {
+      options.agents      = parse_int( "agents", arg );
+      positional_agents   = true;
+    }
+    else
+    {
+      throw std::invalid_argument( "Unknown argument '" + arg + "'" );
+    }
+  }
+  return options;
+}
+
+void
+print_usage()
+{
+  std::cout << "Usage: multi_agent_lqr [--agents N] [--solver NAME] [--strategy NAME] [--max-outer N]\n";
+  std::cout << "       multi_agent_lqr N\n";
+  std::cout << '\n';
+  examples::print_available( std::cout );
+}
+
+} // namespace
 
 /*────────────────────────────  main  ──────────────────────────────*/
 int
 main( int argc, char** argv )
 {
   using namespace mas;
-  const int        N   = ( argc > 1 ) ? std::stoi( argv[1] ) : 10;
-  constexpr int    n_x = 4, n_u = 4, T = 10;
-  constexpr double dt = 0.1;
-
-  MultiAgentProblem problem;
-  for( int i = 0; i < N; ++i )
+  try
   {
-    auto ocp = std::make_shared<OCP>( create_linear_lqr_ocp( n_x, n_u, dt, T ) );
-    problem.add_agent( std::make_shared<Agent>( i, ocp ) );
+    const Options options = parse_options( argc, argv );
+    if( options.show_help )
+    {
+      print_usage();
+      return 0;
+    }
+
+    constexpr int    n_x = 4, n_u = 4, T = 10;
+    constexpr double dt  = 0.1;
+
+    MultiAgentProblem problem;
+    for( int i = 0; i < options.agents; ++i )
+    {
+      auto ocp = std::make_shared<OCP>( create_linear_lqr_ocp( n_x, n_u, dt, T ) );
+      problem.add_agent( std::make_shared<Agent>( i, ocp ) );
+    }
+
+    SolverParams params{
+      { "max_iterations",  100 },
+      {      "tolerance", 1e-5 },
+      {         "max_ms",  100 }
+    };
+
+    auto      solver          = examples::make_solver( options.solver );
+    Strategy  strategy        = examples::make_strategy( options.strategy, std::move( solver ), params, options.max_outer );
+    const auto start          = std::chrono::steady_clock::now();
+    const auto solution       = mas::solve( strategy, problem );
+    const auto end            = std::chrono::steady_clock::now();
+    const double elapsed_ms   = std::chrono::duration<double, std::milli>( end - start ).count();
+    const std::string solver_name   = examples::canonical_solver_name( options.solver );
+    const std::string strategy_name = examples::canonical_strategy_name( options.strategy );
+
+    std::cout << std::fixed << std::setprecision( 6 )
+              << "solver=" << solver_name
+              << " strategy=" << strategy_name
+              << " agents=" << options.agents
+              << " cost=" << solution.total_cost
+              << " time_ms=" << elapsed_ms
+              << '\n';
   }
-
-  SolverParams p{
-    { "max_iterations",  100 },
-    {      "tolerance", 1e-5 },
-    {         "max_ms",  100 }
-  };
-  constexpr int max_outer = 10;
-
-  std::vector<Result> results;
-  auto                time_solver = [&]( const std::string& name, auto&& call ) {
-    for( auto& a : problem.agents )
-      a->reset();
-    auto                                      start   = std::chrono::high_resolution_clock::now();
-    auto                                      sol     = call();
-    auto                                      end     = std::chrono::high_resolution_clock::now();
-    std::chrono::duration<double, std::milli> elapsed = end - start;
-    results.push_back( { name, sol.total_cost, elapsed.count() } );
-  };
-
-  time_solver( "Centralized iLQR", [&]() {
-    Solver solver{ std::in_place_type<iLQR> };
-    set_params( solver, p );
-    Strategy strat = CentralizedStrategy{ std::move( solver ) };
-    return mas::solve( strat, problem );
-  } );
-  time_solver( "Centralized CGD", [&]() {
-    Solver solver{ std::in_place_type<CGD> };
-    set_params( solver, p );
-    Strategy strat = CentralizedStrategy{ std::move( solver ) };
-    return mas::solve( strat, problem );
-  } );
-#ifdef MAS_HAVE_OSQP
-  time_solver( "Centralized OSQP", [&]() {
-    Solver solver{ std::in_place_type<OSQP> };
-    set_params( solver, p );
-    Strategy strat = CentralizedStrategy{ std::move( solver ) };
-    return mas::solve( strat, problem );
-  } );
-  time_solver( "Centralized OSQP-collocation", [&]() {
-    Solver solver{ std::in_place_type<OSQPCollocation> };
-    set_params( solver, p );
-    Strategy strat = CentralizedStrategy{ std::move( solver ) };
-    return mas::solve( strat, problem );
-  } );
-#endif
-
-  time_solver( "Nash Sequential iLQR", [&]() {
-    Solver   solver{ std::in_place_type<iLQR> };
-    Strategy strat = SequentialNashStrategy{ max_outer, std::move( solver ), p };
-    return mas::solve( strat, problem );
-  } );
-  time_solver( "Nash Sequential CGD", [&]() {
-    Solver   solver{ std::in_place_type<CGD> };
-    Strategy strat = SequentialNashStrategy{ max_outer, std::move( solver ), p };
-    return mas::solve( strat, problem );
-  } );
-#ifdef MAS_HAVE_OSQP
-  time_solver( "Nash Sequential OSQP", [&]() {
-    Solver   solver{ std::in_place_type<OSQP> };
-    Strategy strat = SequentialNashStrategy{ max_outer, std::move( solver ), p };
-    return mas::solve( strat, problem );
-  } );
-  time_solver( "Nash Sequential OSQP-collocation", [&]() {
-    Solver   solver{ std::in_place_type<OSQPCollocation> };
-    Strategy strat = SequentialNashStrategy{ max_outer, std::move( solver ), p };
-    return mas::solve( strat, problem );
-  } );
-#endif
-
-  time_solver( "Nash LineSearch iLQR", [&]() {
-    Solver   solver{ std::in_place_type<iLQR> };
-    Strategy strat = LineSearchNashStrategy{ max_outer, std::move( solver ), p };
-    return mas::solve( strat, problem );
-  } );
-  time_solver( "Nash LineSearch CGD", [&]() {
-    Solver   solver{ std::in_place_type<CGD> };
-    Strategy strat = LineSearchNashStrategy{ max_outer, std::move( solver ), p };
-    return mas::solve( strat, problem );
-  } );
-#ifdef MAS_HAVE_OSQP
-  time_solver( "Nash LineSearch OSQP", [&]() {
-    Solver   solver{ std::in_place_type<OSQP> };
-    Strategy strat = LineSearchNashStrategy{ max_outer, std::move( solver ), p };
-    return mas::solve( strat, problem );
-  } );
-  time_solver( "Nash LineSearch OSQP-collocation", [&]() {
-    Solver   solver{ std::in_place_type<OSQPCollocation> };
-    Strategy strat = LineSearchNashStrategy{ max_outer, std::move( solver ), p };
-    return mas::solve( strat, problem );
-  } );
-#endif
-
-  std::cout << std::fixed << std::setprecision( 6 ) << "\n";
-  std::cout << std::setw( 40 ) << std::left << "Method" << std::setw( 15 ) << "Cost" << std::setw( 15 ) << "Time (ms)" << "\n";
-  std::cout << std::string( 70, '-' ) << "\n";
-  for( const auto& r : results )
-    std::cout << std::setw( 40 ) << std::left << r.name << std::setw( 15 ) << r.cost << std::setw( 15 ) << r.time_ms << "\n";
+  catch( const std::exception& e )
+  {
+    std::cerr << "Error: " << e.what() << "\n";
+    std::cerr << "Use --help to see available options.\n";
+    return 1;
+  }
+  return 0;
 }

--- a/examples/multi_agent_single_track.cpp
+++ b/examples/multi_agent_single_track.cpp
@@ -1,7 +1,9 @@
 #include <chrono>
+#include <cmath>
 #include <iomanip>
 #include <iostream>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -10,6 +12,8 @@
 #include "multi_agent_solver/multi_agent_problem.hpp"
 #include "multi_agent_solver/solvers/solver.hpp"
 #include "multi_agent_solver/strategies/strategy.hpp"
+
+#include "example_utils.hpp"
 
 mas::OCP
 create_single_track_circular_ocp( double initial_theta, double track_radius, double target_velocity, int time_steps )
@@ -46,145 +50,155 @@ create_single_track_circular_ocp( double initial_theta, double track_radius, dou
   return problem;
 }
 
-struct Result
+struct Options
 {
-  std::string name;
-  double      cost;
-  double      time_ms;
+  bool        show_help   = false;
+  int         agents      = 10;
+  int         max_outer   = 10;
+  std::string solver      = "ilqr";
+  std::string strategy    = "centralized";
 };
+
+namespace
+{
+
+int
+parse_int( const std::string& label, const std::string& value )
+{
+  try
+  {
+    return std::stoi( value );
+  }
+  catch( const std::exception& )
+  {
+    throw std::invalid_argument( "Invalid value for " + label + ": '" + value + "'" );
+  }
+}
+
+Options
+parse_options( int argc, char** argv )
+{
+  Options options;
+  bool    positional_agents = false;
+  for( int i = 1; i < argc; ++i )
+  {
+    std::string arg = argv[i];
+    auto        match_with_value = [&]( const std::string& name, std::string& out ) {
+      const std::string prefix = name + "=";
+      if( arg == name )
+      {
+        if( i + 1 >= argc )
+          throw std::invalid_argument( "Missing value for option '" + name + "'" );
+        out = argv[++i];
+        return true;
+      }
+      if( arg.rfind( prefix, 0 ) == 0 )
+      {
+        out = arg.substr( prefix.size() );
+        return true;
+      }
+      return false;
+    };
+
+    if( arg == "--help" || arg == "-h" )
+    {
+      options.show_help = true;
+      continue;
+    }
+
+    std::string value;
+    if( match_with_value( "--agents", value ) )
+    {
+      options.agents = parse_int( "--agents", value );
+    }
+    else if( match_with_value( "--solver", value ) )
+    {
+      options.solver = value;
+    }
+    else if( match_with_value( "--strategy", value ) )
+    {
+      options.strategy = value;
+    }
+    else if( match_with_value( "--max-outer", value ) )
+    {
+      options.max_outer = parse_int( "--max-outer", value );
+    }
+    else if( !arg.empty() && arg.front() != '-' && !positional_agents )
+    {
+      options.agents    = parse_int( "agents", arg );
+      positional_agents = true;
+    }
+    else
+    {
+      throw std::invalid_argument( "Unknown argument '" + arg + "'" );
+    }
+  }
+  return options;
+}
+
+void
+print_usage()
+{
+  std::cout << "Usage: multi_agent_single_track [--agents N] [--solver NAME] [--strategy NAME] [--max-outer N]\n";
+  std::cout << "       multi_agent_single_track N\n";
+  std::cout << '\n';
+  examples::print_available( std::cout );
+}
+
+} // namespace
 
 int
 main( int argc, char** argv )
 {
   using namespace mas;
-  SolverParams params{
-    { "max_iterations",  100 },
-    {      "tolerance", 1e-5 },
-    {         "max_ms", 1000 }
-  };
-  constexpr int    max_outer       = 10;
-  const int        num_agents      = ( argc > 1 ) ? std::stoi( argv[1] ) : 10;
-  constexpr int    time_steps      = 10;
-  constexpr double track_radius    = 20.0;
-  constexpr double target_velocity = 10.0;
-
-  MultiAgentProblem problem;
-  for( int i = 0; i < num_agents; ++i )
+  try
   {
-    double theta = 2.0 * M_PI * i / num_agents;
-    auto   ocp   = std::make_shared<OCP>( create_single_track_circular_ocp( theta, track_radius, target_velocity, time_steps ) );
-    problem.add_agent( std::make_shared<Agent>( i, ocp ) );
+    const Options options = parse_options( argc, argv );
+    if( options.show_help )
+    {
+      print_usage();
+      return 0;
+    }
+
+    SolverParams params{
+      { "max_iterations",  100 },
+      {      "tolerance", 1e-5 },
+      {         "max_ms", 1000 }
+    };
+    constexpr int    time_steps      = 10;
+    constexpr double track_radius    = 20.0;
+    constexpr double target_velocity = 10.0;
+
+    MultiAgentProblem problem;
+    for( int i = 0; i < options.agents; ++i )
+    {
+      double theta = 2.0 * M_PI * i / options.agents;
+      auto   ocp   = std::make_shared<OCP>( create_single_track_circular_ocp( theta, track_radius, target_velocity, time_steps ) );
+      problem.add_agent( std::make_shared<Agent>( i, ocp ) );
+    }
+
+    auto      solver          = examples::make_solver( options.solver );
+    Strategy  strategy        = examples::make_strategy( options.strategy, std::move( solver ), params, options.max_outer );
+    const auto start          = std::chrono::steady_clock::now();
+    const auto solution       = mas::solve( strategy, problem );
+    const auto end            = std::chrono::steady_clock::now();
+    const double elapsed_ms   = std::chrono::duration<double, std::milli>( end - start ).count();
+    const std::string solver_name   = examples::canonical_solver_name( options.solver );
+    const std::string strategy_name = examples::canonical_strategy_name( options.strategy );
+
+    std::cout << std::fixed << std::setprecision( 6 )
+              << "solver=" << solver_name
+              << " strategy=" << strategy_name
+              << " agents=" << options.agents
+              << " cost=" << solution.total_cost
+              << " time_ms=" << elapsed_ms
+              << '\n';
   }
-
-  std::vector<Result> results;
-  auto                time_solver = [&]( const std::string& name, auto&& call ) {
-    for( auto& a : problem.agents )
-      a->reset();
-    auto                                      start   = std::chrono::high_resolution_clock::now();
-    auto                                      sol     = call();
-    auto                                      end     = std::chrono::high_resolution_clock::now();
-    std::chrono::duration<double, std::milli> elapsed = end - start;
-    results.push_back( { name, sol.total_cost, elapsed.count() } );
-  };
-
-  time_solver( "Centralized CGD", [&]() {
-    Solver solver{ std::in_place_type<CGD> };
-    set_params( solver, params );
-    Strategy strat = CentralizedStrategy{ std::move( solver ) };
-    return mas::solve( strat, problem );
-  } );
-  time_solver( "Centralized iLQR", [&]() {
-    Solver solver{ std::in_place_type<iLQR> };
-    set_params( solver, params );
-    Strategy strat = CentralizedStrategy{ std::move( solver ) };
-    return mas::solve( strat, problem );
-  } );
-#ifdef MAS_HAVE_OSQP
-  time_solver( "Centralized OSQP", [&]() {
-    Solver solver{ std::in_place_type<OSQP> };
-    set_params( solver, params );
-    Strategy strat = CentralizedStrategy{ std::move( solver ) };
-    return mas::solve( strat, problem );
-  } );
-  time_solver( "Centralized OSQP-collocation", [&]() {
-    Solver solver{ std::in_place_type<OSQPCollocation> };
-    set_params( solver, params );
-    Strategy strat = CentralizedStrategy{ std::move( solver ) };
-    return mas::solve( strat, problem );
-  } );
-#endif
-  time_solver( "Nash Sequential CGD", [&]() {
-    Solver   solver{ std::in_place_type<CGD> };
-    Strategy strat = SequentialNashStrategy{ max_outer, std::move( solver ), params };
-    return mas::solve( strat, problem );
-  } );
-  time_solver( "Nash Sequential iLQR", [&]() {
-    Solver   solver{ std::in_place_type<iLQR> };
-    Strategy strat = SequentialNashStrategy{ max_outer, std::move( solver ), params };
-    return mas::solve( strat, problem );
-  } );
-#ifdef MAS_HAVE_OSQP
-  time_solver( "Nash Sequential OSQP", [&]() {
-    Solver   solver{ std::in_place_type<OSQP> };
-    Strategy strat = SequentialNashStrategy{ max_outer, std::move( solver ), params };
-    return mas::solve( strat, problem );
-  } );
-  time_solver( "Nash Sequential OSQP-collocation", [&]() {
-    Solver   solver{ std::in_place_type<OSQPCollocation> };
-    Strategy strat = SequentialNashStrategy{ max_outer, std::move( solver ), params };
-    return mas::solve( strat, problem );
-  } );
-#endif
-
-  time_solver( "Nash LineSearch CGD", [&]() {
-    Solver   solver{ std::in_place_type<CGD> };
-    Strategy strat = LineSearchNashStrategy{ max_outer, std::move( solver ), params };
-    return mas::solve( strat, problem );
-  } );
-  time_solver( "Nash LineSearch iLQR", [&]() {
-    Solver   solver{ std::in_place_type<iLQR> };
-    Strategy strat = LineSearchNashStrategy{ max_outer, std::move( solver ), params };
-    return mas::solve( strat, problem );
-  } );
-#ifdef MAS_HAVE_OSQP
-  time_solver( "Nash LineSearch OSQP", [&]() {
-    Solver   solver{ std::in_place_type<OSQP> };
-    Strategy strat = LineSearchNashStrategy{ max_outer, std::move( solver ), params };
-    return mas::solve( strat, problem );
-  } );
-  time_solver( "Nash LineSearch OSQP-collocation", [&]() {
-    Solver   solver{ std::in_place_type<OSQPCollocation> };
-    Strategy strat = LineSearchNashStrategy{ max_outer, std::move( solver ), params };
-    return mas::solve( strat, problem );
-  } );
-#endif
-
-  time_solver( "Nash TrustRegion CGD", [&]() {
-    Solver   solver{ std::in_place_type<CGD> };
-    Strategy strat = TrustRegionNashStrategy{ max_outer, std::move( solver ), params };
-    return mas::solve( strat, problem );
-  } );
-  time_solver( "Nash TrustRegion iLQR", [&]() {
-    Solver   solver{ std::in_place_type<iLQR> };
-    Strategy strat = TrustRegionNashStrategy{ max_outer, std::move( solver ), params };
-    return mas::solve( strat, problem );
-  } );
-#ifdef MAS_HAVE_OSQP
-  time_solver( "Nash TrustRegion OSQP", [&]() {
-    Solver   solver{ std::in_place_type<OSQP> };
-    Strategy strat = TrustRegionNashStrategy{ max_outer, std::move( solver ), params };
-    return mas::solve( strat, problem );
-  } );
-  time_solver( "Nash TrustRegion OSQP-collocation", [&]() {
-    Solver   solver{ std::in_place_type<OSQPCollocation> };
-    Strategy strat = TrustRegionNashStrategy{ max_outer, std::move( solver ), params };
-    return mas::solve( strat, problem );
-  } );
-#endif
-
-  std::cout << std::fixed << std::setprecision( 3 ) << "\n";
-  std::cout << std::setw( 40 ) << std::left << "Method" << std::setw( 15 ) << "Cost" << std::setw( 15 ) << "Time (ms)" << "\n";
-  std::cout << std::string( 70, '-' ) << "\n";
-  for( const auto& r : results )
-    std::cout << std::setw( 40 ) << std::left << r.name << std::setw( 15 ) << r.cost << std::setw( 15 ) << r.time_ms << "\n";
+  catch( const std::exception& e )
+  {
+    std::cerr << "Error: " << e.what() << "\n";
+    std::cerr << "Use --help to see available options.\n";
+    return 1;
+  }
+  return 0;
 }

--- a/examples/multi_agent_single_track.cpp
+++ b/examples/multi_agent_single_track.cpp
@@ -1,4 +1,6 @@
+#include <charconv>
 #include <chrono>
+#include <system_error>
 #include <cmath>
 #include <iomanip>
 #include <iostream>
@@ -65,14 +67,13 @@ namespace
 int
 parse_int( const std::string& label, const std::string& value )
 {
-  try
-  {
-    return std::stoi( value );
-  }
-  catch( const std::exception& )
-  {
+  int result = 0;
+  const char* begin = value.data();
+  const char* end   = begin + value.size();
+  const auto   [ptr, ec] = std::from_chars( begin, end, result );
+  if( ec != std::errc() || ptr != end )
     throw std::invalid_argument( "Invalid value for " + label + ": '" + value + "'" );
-  }
+  return result;
 }
 
 Options

--- a/examples/multi_agent_single_track.cpp
+++ b/examples/multi_agent_single_track.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <charconv>
 #include <chrono>
 #include <system_error>
@@ -84,6 +85,12 @@ parse_options( int argc, char** argv )
   for( int i = 1; i < argc; ++i )
   {
     std::string arg = argv[i];
+    if( arg.rfind( "--", 0 ) == 0 )
+    {
+      const auto eq_pos = arg.find( '=' );
+      const auto end    = eq_pos == std::string::npos ? arg.size() : eq_pos;
+      std::replace( arg.begin() + 2, arg.begin() + static_cast<std::ptrdiff_t>( end ), '_', '-' );
+    }
     auto        match_with_value = [&]( const std::string& name, std::string& out ) {
       const std::string prefix = name + "=";
       if( arg == name )

--- a/examples/pendulum_swing_up.cpp
+++ b/examples/pendulum_swing_up.cpp
@@ -1,13 +1,16 @@
 #include <chrono>
+#include <cmath>
 #include <iomanip>
 #include <iostream>
-#include <map>
+#include <stdexcept>
 #include <string>
 
 #include "models/pendulum_model.hpp"
 #include "multi_agent_solver/ocp.hpp"
 #include "multi_agent_solver/solvers/solver.hpp"
 #include "multi_agent_solver/types.hpp"
+
+#include "example_utils.hpp"
 
 mas::OCP
 create_pendulum_swingup_ocp()
@@ -85,47 +88,108 @@ create_pendulum_swingup_ocp()
   return problem;
 }
 
+struct Options
+{
+  bool        show_help = false;
+  std::string solver    = "ilqr";
+};
+
+namespace
+{
+
+Options
+parse_options( int argc, char** argv )
+{
+  Options options;
+  for( int i = 1; i < argc; ++i )
+  {
+    std::string arg = argv[i];
+    auto        match_with_value = [&]( const std::string& name, std::string& out ) {
+      const std::string prefix = name + "=";
+      if( arg == name )
+      {
+        if( i + 1 >= argc )
+          throw std::invalid_argument( "Missing value for option '" + name + "'" );
+        out = argv[++i];
+        return true;
+      }
+      if( arg.rfind( prefix, 0 ) == 0 )
+      {
+        out = arg.substr( prefix.size() );
+        return true;
+      }
+      return false;
+    };
+
+    if( arg == "--help" || arg == "-h" )
+    {
+      options.show_help = true;
+      continue;
+    }
+
+    std::string value;
+    if( match_with_value( "--solver", value ) )
+    {
+      options.solver = value;
+    }
+    else
+    {
+      throw std::invalid_argument( "Unknown argument '" + arg + "'" );
+    }
+  }
+  return options;
+}
+
+void
+print_usage()
+{
+  std::cout << "Usage: pendulum_swing_up [--solver NAME]\n";
+  std::cout << '\n';
+  examples::print_available( std::cout );
+}
+
+} // namespace
+
 int
-main( int, char** )
+main( int argc, char** argv )
 {
   using namespace mas;
-  OCP problem = create_pendulum_swingup_ocp();
-
-  SolverParams params;
-  params["max_iterations"] = 500;
-  params["tolerance"]      = 1e-5;
-  params["max_ms"]         = 1000;
-
-  std::map<std::string, Solver> solvers;
-  solvers.emplace( "iLQR", iLQR() );
-  solvers.emplace( "CGD", CGD() );
-#ifdef MAS_HAVE_OSQP
-  solvers.emplace( "OSQP", OSQP() );
-  solvers.emplace( "OSQP Collocation", OSQPCollocation() );
-#endif
-
-  struct SolverResult
+  try
   {
-    double cost;
-    double time_ms;
-  };
+    const Options options = parse_options( argc, argv );
+    if( options.show_help )
+    {
+      print_usage();
+      return 0;
+    }
 
-  std::map<std::string, SolverResult> results;
+    OCP problem = create_pendulum_swingup_ocp();
 
-  for( auto& [name, solver] : solvers )
-  {
-    auto problem_copy = problem;
-    auto start        = std::chrono::high_resolution_clock::now();
+    SolverParams params;
+    params["max_iterations"] = 500;
+    params["tolerance"]      = 1e-5;
+    params["max_ms"]         = 1000;
+
+    auto solver = examples::make_solver( options.solver );
     mas::set_params( solver, params );
-    mas::solve( solver, problem_copy );
-    auto end      = std::chrono::high_resolution_clock::now();
-    results[name] = { problem_copy.best_cost, std::chrono::duration<double, std::milli>( end - start ).count() };
-  }
 
-  std::cout << "\nPendulum Swing-Up Test\n"
-            << "---------------------------------------------\n"
-            << std::left << std::setw( 20 ) << "Solver" << std::setw( 15 ) << "Cost" << std::setw( 15 ) << "Time (ms)\n"
-            << "---------------------------------------------\n";
-  for( const auto& [name, res] : results )
-    std::cout << std::left << std::setw( 20 ) << name << std::setw( 15 ) << res.cost << std::setw( 15 ) << res.time_ms << '\n';
+    const auto start        = std::chrono::steady_clock::now();
+    mas::solve( solver, problem );
+    const auto end          = std::chrono::steady_clock::now();
+    const double elapsed_ms = std::chrono::duration<double, std::milli>( end - start ).count();
+
+    const std::string solver_name = examples::canonical_solver_name( options.solver );
+    std::cout << std::fixed << std::setprecision( 6 )
+              << "solver=" << solver_name
+              << " cost=" << problem.best_cost
+              << " time_ms=" << elapsed_ms
+              << '\n';
+  }
+  catch( const std::exception& e )
+  {
+    std::cerr << "Error: " << e.what() << "\n";
+    std::cerr << "Use --help to see available options.\n";
+    return 1;
+  }
+  return 0;
 }

--- a/scripts/compare_solvers.py
+++ b/scripts/compare_solvers.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Utility to benchmark example executables across solver and strategy choices."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+MULTI_AGENT_EXAMPLES = {
+    "multi_agent_lqr",
+    "multi_agent_single_track",
+}
+SINGLE_AGENT_EXAMPLES = {
+    "single_track_ocp",
+    "pendulum_swing_up",
+}
+
+ALL_EXAMPLES = tuple(sorted(MULTI_AGENT_EXAMPLES | SINGLE_AGENT_EXAMPLES))
+
+
+@dataclass
+class CommandResult:
+    stdout: str
+    stderr: str
+    returncode: int
+
+
+def parse_arguments(argv: Optional[Iterable[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        default=Path("build/relwithdebinfo"),
+        help="Path to the CMake build directory that contains the example executables.",
+    )
+    parser.add_argument(
+        "--examples",
+        nargs="*",
+        default=list(ALL_EXAMPLES),
+        choices=ALL_EXAMPLES,
+        help="Subset of examples to benchmark.",
+    )
+    parser.add_argument(
+        "--solvers",
+        nargs="+",
+        default=["ilqr", "cgd"],
+        help="Solvers to test. Names are passed directly to the executables.",
+    )
+    parser.add_argument(
+        "--strategies",
+        nargs="+",
+        default=["centralized", "sequential", "linesearch", "trustregion"],
+        help="Strategies to test for multi-agent examples.",
+    )
+    parser.add_argument(
+        "--agents",
+        type=int,
+        default=10,
+        help="Number of agents for multi-agent examples.",
+    )
+    parser.add_argument(
+        "--max-outer",
+        dest="max_outer",
+        type=int,
+        default=10,
+        help="Maximum outer iterations for Nash strategies.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        help="Optional timeout (in seconds) for each executable invocation.",
+    )
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Abort on the first failing executable invocation.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print commands before executing them and echo their stderr output.",
+    )
+    return parser.parse_args(argv)
+
+
+def run_command(cmd: List[str], timeout: Optional[float], verbose: bool) -> CommandResult:
+    if verbose:
+        print("$", " ".join(cmd))
+    process = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if verbose and process.stderr:
+        sys.stderr.write(process.stderr)
+    return CommandResult(process.stdout, process.stderr, process.returncode)
+
+
+def find_result_line(output: str) -> Optional[str]:
+    for line in reversed(output.splitlines()):
+        if "cost=" in line and "time_ms=" in line:
+            return line.strip()
+    return None
+
+
+def parse_result_line(line: str) -> Dict[str, str]:
+    data: Dict[str, str] = {}
+    for token in line.split():
+        if "=" not in token:
+            continue
+        key, value = token.split("=", 1)
+        data[key] = value
+    return data
+
+
+def format_table(rows: List[Dict[str, str]], include_strategy: bool) -> str:
+    if not rows:
+        return "(no successful runs)"
+
+    def fmt_float(value: str, precision: int = 6) -> str:
+        try:
+            return f"{float(value):.{precision}f}"
+        except ValueError:
+            return value
+
+    headers = ["solver"]
+    if include_strategy:
+        headers.append("strategy")
+    headers.extend(["cost", "time_ms"])
+
+    display_rows: List[List[str]] = []
+    for row in rows:
+        solver = row.get("solver", "")
+        cost = fmt_float(row.get("cost", ""))
+        time_ms = fmt_float(row.get("time_ms", ""), precision=3)
+        values = [solver]
+        if include_strategy:
+            values.append(row.get("strategy", ""))
+        values.extend([cost, time_ms])
+        display_rows.append(values)
+
+    widths = [len(header) for header in headers]
+    for row in display_rows:
+        for idx, value in enumerate(row):
+            widths[idx] = max(widths[idx], len(value))
+
+    lines = [
+        " ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers)),
+        "-" * (sum(widths) + len(widths) - 1),
+    ]
+    for row in display_rows:
+        lines.append(" ".join(value.ljust(widths[idx]) for idx, value in enumerate(row)))
+    return "\n".join(lines)
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = parse_arguments(argv)
+    build_dir = args.build_dir
+
+    results: Dict[str, List[Dict[str, str]]] = {example: [] for example in args.examples}
+
+    for example in args.examples:
+        executable = build_dir / example
+        if not executable.exists():
+            sys.stderr.write(f"Warning: executable '{executable}' not found. Skipping {example}.\n")
+            continue
+
+        if example in MULTI_AGENT_EXAMPLES:
+            for solver in args.solvers:
+                for strategy in args.strategies:
+                    cmd = [str(executable), f"--solver={solver}", f"--strategy={strategy}", f"--agents={args.agents}", f"--max-outer={args.max_outer}"]
+                    result = run_command(cmd, args.timeout, args.verbose)
+                    if result.returncode != 0:
+                        sys.stderr.write(
+                            f"Error: '{example}' with solver={solver} strategy={strategy} exited with code {result.returncode}.\n"
+                        )
+                        if result.stderr:
+                            sys.stderr.write(result.stderr + "\n")
+                        if args.fail_fast:
+                            return result.returncode or 1
+                        continue
+                    line = find_result_line(result.stdout)
+                    if not line:
+                        sys.stderr.write(
+                            f"Error: could not parse output from '{example}' with solver={solver} strategy={strategy}.\n"
+                        )
+                        if args.fail_fast:
+                            return 1
+                        continue
+                    data = parse_result_line(line)
+                    data.setdefault("solver", solver)
+                    data.setdefault("strategy", strategy)
+                    results[example].append(data)
+        else:
+            for solver in args.solvers:
+                cmd = [str(executable), f"--solver={solver}"]
+                result = run_command(cmd, args.timeout, args.verbose)
+                if result.returncode != 0:
+                    sys.stderr.write(
+                        f"Error: '{example}' with solver={solver} exited with code {result.returncode}.\n"
+                    )
+                    if result.stderr:
+                        sys.stderr.write(result.stderr + "\n")
+                    if args.fail_fast:
+                        return result.returncode or 1
+                    continue
+                line = find_result_line(result.stdout)
+                if not line:
+                    sys.stderr.write(
+                        f"Error: could not parse output from '{example}' with solver={solver}.\n"
+                    )
+                    if args.fail_fast:
+                        return 1
+                    continue
+                data = parse_result_line(line)
+                data.setdefault("solver", solver)
+                results[example].append(data)
+
+    for example in args.examples:
+        rows = results.get(example, [])
+        include_strategy = example in MULTI_AGENT_EXAMPLES
+        print(f"\n=== {example} ===")
+        print(format_table(rows, include_strategy))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/profile.sh
+++ b/scripts/profile.sh
@@ -1,13 +1,41 @@
 #!/bin/bash
 
-BUILD_DIR="build/relwithdebinfo/bin"
-EXE_NAME=${1:-main_example}
+set -euo pipefail
 
-if [ ! -f "${BUILD_DIR}/${EXE_NAME}" ]; then
-    echo "⚠️  Build not found. Building with debug info..."
-    ./scripts/build.sh RelWithDebInfo
+BUILD_TYPE="RelWithDebInfo"
+BUILD_DIR="build/${BUILD_TYPE,,}"
+EXE_NAME=${1:-multi_agent_lqr}
+shift || true
+
+if ! command -v perf >/dev/null 2>&1; then
+    echo "❌ 'perf' is required but not installed."
+    exit 1
 fi
 
-echo "📊 Running performance analysis using perf..."
-perf record -g -- "${BUILD_DIR}/${EXE_NAME}"
+if [ ! -d "${BUILD_DIR}" ]; then
+    echo "⚠️  Build directory not found. Building with debug info..."
+    ./scripts/build.sh "${BUILD_TYPE}"
+fi
+
+BINARY_PATH=""
+if [ -x "${BUILD_DIR}/${EXE_NAME}" ]; then
+    BINARY_PATH="${BUILD_DIR}/${EXE_NAME}"
+else
+    BINARY_PATH=$(find "${BUILD_DIR}" -maxdepth 3 -type f -name "${EXE_NAME}" -perm -u+x | head -n 1)
+fi
+
+if [ -z "${BINARY_PATH}" ] || [ ! -x "${BINARY_PATH}" ]; then
+    echo "❌ Executable '${EXE_NAME}' not found in ${BUILD_DIR}." >&2
+    echo "   Available executables:" >&2
+    find "${BUILD_DIR}" -maxdepth 3 -type f -perm -u+x -printf "   %P\n" | sort >&2
+    exit 1
+fi
+
+if [ ! -f "${BUILD_DIR}/CMakeCache.txt" ]; then
+    echo "⚠️  Build artifacts missing. Rebuilding..."
+    ./scripts/build.sh "${BUILD_TYPE}"
+fi
+
+echo "📊 Running performance analysis on ${BINARY_PATH} using perf..."
+perf record -g -- "${BINARY_PATH}" "$@"
 perf report


### PR DESCRIPTION
## Summary
- add a shared helper to normalize solver and strategy names and build the appropriate variants for the examples
- update each example executable to accept solver (and strategy where appropriate) CLI options and emit concise cost/time measurements for a single run
- add a Python utility that iterates over requested solver/strategy combinations and prints comparison tables for all examples
