### PR TITLE
Improve OSQP terminal costs and add rocket example

### DIFF
--- a/examples/models/rocket_model.hpp
+++ b/examples/models/rocket_model.hpp
@@ -1,49 +1,65 @@
 #pragma once
 
+#include <algorithm>
+
 #include <Eigen/Dense>
 
 #include "multi_agent_solver/types.hpp"
 
-namespace mas::examples
+namespace mas
 {
 
 struct RocketParameters
 {
-  double mass     = 1.0;  ///< Vehicle mass [kg]
-  double gravity  = 9.81; ///< Gravity [m/s^2]
+  double initial_mass     = 1.0;  ///< Initial vehicle mass [kg]
+  double gravity          = 9.81; ///< Gravity [m/s^2]
+  double exhaust_velocity = 25.0; ///< Effective exhaust velocity [m/s]
 };
 
 inline mas::State
 rocket_dynamics( const RocketParameters& params, const mas::State& state, const mas::Control& control )
 {
-  mas::State derivative = mas::State::Zero( 2 );
-  derivative( 0 )       = state( 1 );
-  derivative( 1 )       = control( 0 ) / params.mass - params.gravity;
+  mas::State derivative = mas::State::Zero( 3 );
+
+  const double mass   = std::max( state( 2 ), 1e-6 );
+  const double thrust = control( 0 );
+
+  derivative( 0 ) = state( 1 );
+  derivative( 1 ) = thrust / mass - params.gravity;
+  derivative( 2 ) = -thrust / params.exhaust_velocity;
+
   return derivative;
 }
 
 inline mas::MotionModel
 make_rocket_dynamics( const RocketParameters& params )
 {
-  return [params]( const mas::State& state, const mas::Control& control ) {
-    return rocket_dynamics( params, state, control );
-  };
+  return [params]( const mas::State& state, const mas::Control& control ) { return rocket_dynamics( params, state, control ); };
 }
 
 inline Eigen::MatrixXd
-rocket_state_jacobian( const RocketParameters&, const mas::State&, const mas::Control& )
+rocket_state_jacobian( const RocketParameters&, const mas::State& state, const mas::Control& control )
 {
-  Eigen::MatrixXd A = Eigen::MatrixXd::Zero( 2, 2 );
+  Eigen::MatrixXd A = Eigen::MatrixXd::Zero( 3, 3 );
   A( 0, 1 )         = 1.0;
+
+  const double thrust = control( 0 );
+  const double mass   = std::max( state( 2 ), 1e-6 );
+
+  A( 1, 2 ) = -thrust / ( mass * mass );
+
   return A;
 }
 
 inline Eigen::MatrixXd
-rocket_control_jacobian( const RocketParameters& params, const mas::State&, const mas::Control& )
+rocket_control_jacobian( const RocketParameters& params, const mas::State& state, const mas::Control& )
 {
-  Eigen::MatrixXd B = Eigen::MatrixXd::Zero( 2, 1 );
-  B( 1, 0 )         = 1.0 / params.mass;
+  Eigen::MatrixXd B    = Eigen::MatrixXd::Zero( 3, 1 );
+  const double    mass = std::max( state( 2 ), 1e-6 );
+
+  B( 1, 0 ) = 1.0 / mass;
+  B( 2, 0 ) = -1.0 / params.exhaust_velocity;
   return B;
 }
 
-} // namespace mas::examples
+} // namespace mas

--- a/examples/models/rocket_model.hpp
+++ b/examples/models/rocket_model.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <Eigen/Dense>
+
+#include "multi_agent_solver/types.hpp"
+
+namespace mas::examples
+{
+
+struct RocketParameters
+{
+  double mass     = 1.0;  ///< Vehicle mass [kg]
+  double gravity  = 9.81; ///< Gravity [m/s^2]
+};
+
+inline mas::State
+rocket_dynamics( const RocketParameters& params, const mas::State& state, const mas::Control& control )
+{
+  mas::State derivative = mas::State::Zero( 2 );
+  derivative( 0 )       = state( 1 );
+  derivative( 1 )       = control( 0 ) / params.mass - params.gravity;
+  return derivative;
+}
+
+inline mas::MotionModel
+make_rocket_dynamics( const RocketParameters& params )
+{
+  return [params]( const mas::State& state, const mas::Control& control ) {
+    return rocket_dynamics( params, state, control );
+  };
+}
+
+inline Eigen::MatrixXd
+rocket_state_jacobian( const RocketParameters&, const mas::State&, const mas::Control& )
+{
+  Eigen::MatrixXd A = Eigen::MatrixXd::Zero( 2, 2 );
+  A( 0, 1 )         = 1.0;
+  return A;
+}
+
+inline Eigen::MatrixXd
+rocket_control_jacobian( const RocketParameters& params, const mas::State&, const mas::Control& )
+{
+  Eigen::MatrixXd B = Eigen::MatrixXd::Zero( 2, 1 );
+  B( 1, 0 )         = 1.0 / params.mass;
+  return B;
+}
+
+} // namespace mas::examples

--- a/examples/rocket_max_altitude.cpp
+++ b/examples/rocket_max_altitude.cpp
@@ -1,4 +1,3 @@
-#include <iomanip>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -9,84 +8,53 @@
 #include "multi_agent_solver/solvers/solver.hpp"
 #include "multi_agent_solver/types.hpp"
 
-namespace
+namespace mas
 {
 
 mas::OCP
 create_max_altitude_rocket_ocp()
 {
-  using namespace mas;
-
-  examples::RocketParameters params;
-  params.mass    = 1.0;
-  params.gravity = 9.81;
+  RocketParameters params;
+  params.initial_mass     = 1.0;
+  params.gravity          = 9.81;
+  params.exhaust_velocity = 25.0;
 
   OCP problem;
-  problem.state_dim     = 2;
+  problem.state_dim     = 3;
   problem.control_dim   = 1;
   problem.horizon_steps = 40;
   problem.dt            = 0.1;
 
-  problem.initial_state = State::Zero( problem.state_dim );
+  problem.initial_state      = State::Zero( problem.state_dim );
+  problem.initial_state( 2 ) = params.initial_mass;
 
-  problem.dynamics = examples::make_rocket_dynamics( params );
+  problem.dynamics = make_rocket_dynamics( params );
 
-  const double max_thrust            = 20.0; // [N]
-  const double w_thrust              = 5e-3;
-  const double w_terminal_altitude   = 15.0;
-  const double w_terminal_velocity   = 2.0;
-  const double desired_terminal_vel  = 0.0;
+  const double max_thrust           = 20.0; // [N]
+  const double w_thrust             = 5e-3;
+  const double w_terminal_altitude  = 15.0;
+  const double w_terminal_velocity  = 2.0;
+  const double desired_terminal_vel = 0.0;
 
-  problem.stage_cost = [=]( const State&, const Control& control, size_t ) {
+  problem.stage_cost = [=]( const State& state, const Control& control, size_t ) {
     const double thrust = control( 0 );
     return 0.5 * w_thrust * thrust * thrust;
   };
 
-  problem.cost_state_gradient = []( const StageCostFunction&, const State& state, const Control&, size_t ) {
-    return Eigen::VectorXd::Zero( state.size() );
-  };
-
-  problem.cost_state_hessian = []( const StageCostFunction&, const State& state, const Control&, size_t ) {
-    return Eigen::MatrixXd::Zero( state.size(), state.size() );
-  };
-
-  problem.cost_control_gradient = [=]( const StageCostFunction&, const State&, const Control& control, size_t ) {
-    Eigen::VectorXd grad = Eigen::VectorXd::Zero( control.size() );
-    grad( 0 )            = w_thrust * control( 0 );
-    return grad;
-  };
-
-  problem.cost_control_hessian = [=]( const StageCostFunction&, const State&, const Control&, size_t ) {
-    Eigen::MatrixXd H = Eigen::MatrixXd::Zero( 1, 1 );
-    H( 0, 0 )         = w_thrust;
-    return H;
-  };
 
   problem.terminal_cost = [=]( const State& state ) {
-    const double altitude        = state( 0 );
-    const double velocity_error  = state( 1 ) - desired_terminal_vel;
+    const double altitude       = state( 0 );
+    const double velocity_error = state( 1 ) - desired_terminal_vel;
     return -w_terminal_altitude * altitude + 0.5 * w_terminal_velocity * velocity_error * velocity_error;
   };
 
-  problem.terminal_cost_gradient = [=]( const TerminalCostFunction&, const State& state ) {
-    Eigen::VectorXd grad = Eigen::VectorXd::Zero( state.size() );
-    grad( 0 )            = -w_terminal_altitude;
-    grad( 1 )            = w_terminal_velocity * ( state( 1 ) - desired_terminal_vel );
-    return grad;
-  };
-
-  problem.terminal_cost_hessian = [=]( const TerminalCostFunction&, const State& state ) {
-    Eigen::MatrixXd H = Eigen::MatrixXd::Zero( state.size(), state.size() );
-    H( 1, 1 )         = w_terminal_velocity;
-    return H;
-  };
 
   problem.dynamics_state_jacobian = [=]( const MotionModel&, const State& state, const Control& control ) {
-    return examples::rocket_state_jacobian( params, state, control );
+    return rocket_state_jacobian( params, state, control );
   };
 
   problem.dynamics_control_jacobian = [=]( const MotionModel&, const State& state, const Control& control ) {
-    return examples::rocket_control_jacobian( params, state, control );
+    return rocket_control_jacobian( params, state, control );
   };
 
   Eigen::VectorXd u_lower( 1 ), u_upper( 1 );
@@ -94,6 +62,14 @@ create_max_altitude_rocket_ocp()
   u_upper << max_thrust;
   problem.input_lower_bounds = u_lower;
   problem.input_upper_bounds = u_upper;
+
+  Eigen::VectorXd x_lower    = Eigen::VectorXd::Constant( problem.state_dim, std::numeric_limits<double>::min() );
+  x_lower( 2 )               = 0.0;
+  problem.state_lower_bounds = x_lower;
+
+  Eigen::VectorXd x_upper    = Eigen::VectorXd::Constant( problem.state_dim, std::numeric_limits<double>::max() );
+  x_upper( 2 )               = params.initial_mass;
+  problem.state_upper_bounds = x_upper;
 
   problem.initialize_problem();
   problem.verify_problem();
@@ -154,7 +130,7 @@ print_usage()
   examples::print_available( std::cout );
 }
 
-} // namespace
+} // namespace mas
 
 int
 main( int argc, char** argv )
@@ -178,25 +154,25 @@ main( int argc, char** argv )
     params["max_ms"]         = 200;
 
     Solver solver = examples::make_solver( options.solver );
-    mas::set_params( solver, params );
+    set_params( solver, params );
+    const auto start = std::chrono::steady_clock::now();
     mas::solve( solver, problem );
-
-    const auto& X = problem.best_states;
-    const int   T = problem.horizon_steps;
+    const auto   end        = std::chrono::steady_clock::now();
+    const double elapsed_ms = std::chrono::duration<double, std::milli>( end - start ).count();
+    const auto&  X          = problem.best_states;
+    const int    T          = problem.horizon_steps;
 
     const double final_altitude = X( 0, T );
     const double final_velocity = X( 1, T );
+    const double final_mass     = X( 2, T );
 
-    std::cout << std::fixed << std::setprecision( 3 );
-    std::cout << "Best cost: " << problem.best_cost << '\n';
-    std::cout << "Final altitude: " << final_altitude << " m\n";
-    std::cout << "Final velocity: " << final_velocity << " m/s\n";
+    const std::string solver_name = examples::canonical_solver_name( options.solver );
+    std::cout << std::fixed << std::setprecision( 6 ) << "solver=" << solver_name << " cost=" << problem.best_cost
+              << " time_ms=" << elapsed_ms << '\n';
 
-    if( options.dump_traces )
-    {
-      examples::print_state_trajectory( std::cout, X, problem.dt, "rocket" );
-      examples::print_control_trajectory( std::cout, problem.best_controls, problem.dt, "rocket" );
-    }
+
+    examples::print_state_trajectory( std::cout, problem.best_states, problem.dt, "rocket" );
+    examples::print_control_trajectory( std::cout, problem.best_controls, problem.dt, "rocket" );
   }
   catch( const std::exception& ex )
   {

--- a/examples/rocket_max_altitude.cpp
+++ b/examples/rocket_max_altitude.cpp
@@ -1,0 +1,207 @@
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+#include "example_utils.hpp"
+#include "models/rocket_model.hpp"
+#include "multi_agent_solver/ocp.hpp"
+#include "multi_agent_solver/solvers/solver.hpp"
+#include "multi_agent_solver/types.hpp"
+
+namespace
+{
+
+mas::OCP
+create_max_altitude_rocket_ocp()
+{
+  using namespace mas;
+
+  examples::RocketParameters params;
+  params.mass    = 1.0;
+  params.gravity = 9.81;
+
+  OCP problem;
+  problem.state_dim     = 2;
+  problem.control_dim   = 1;
+  problem.horizon_steps = 40;
+  problem.dt            = 0.1;
+
+  problem.initial_state = State::Zero( problem.state_dim );
+
+  problem.dynamics = examples::make_rocket_dynamics( params );
+
+  const double max_thrust            = 20.0; // [N]
+  const double w_thrust              = 5e-3;
+  const double w_terminal_altitude   = 15.0;
+  const double w_terminal_velocity   = 2.0;
+  const double desired_terminal_vel  = 0.0;
+
+  problem.stage_cost = [=]( const State&, const Control& control, size_t ) {
+    const double thrust = control( 0 );
+    return 0.5 * w_thrust * thrust * thrust;
+  };
+
+  problem.cost_state_gradient = []( const StageCostFunction&, const State& state, const Control&, size_t ) {
+    return Eigen::VectorXd::Zero( state.size() );
+  };
+
+  problem.cost_state_hessian = []( const StageCostFunction&, const State& state, const Control&, size_t ) {
+    return Eigen::MatrixXd::Zero( state.size(), state.size() );
+  };
+
+  problem.cost_control_gradient = [=]( const StageCostFunction&, const State&, const Control& control, size_t ) {
+    Eigen::VectorXd grad = Eigen::VectorXd::Zero( control.size() );
+    grad( 0 )            = w_thrust * control( 0 );
+    return grad;
+  };
+
+  problem.cost_control_hessian = [=]( const StageCostFunction&, const State&, const Control&, size_t ) {
+    Eigen::MatrixXd H = Eigen::MatrixXd::Zero( 1, 1 );
+    H( 0, 0 )         = w_thrust;
+    return H;
+  };
+
+  problem.terminal_cost = [=]( const State& state ) {
+    const double altitude        = state( 0 );
+    const double velocity_error  = state( 1 ) - desired_terminal_vel;
+    return -w_terminal_altitude * altitude + 0.5 * w_terminal_velocity * velocity_error * velocity_error;
+  };
+
+  problem.terminal_cost_gradient = [=]( const TerminalCostFunction&, const State& state ) {
+    Eigen::VectorXd grad = Eigen::VectorXd::Zero( state.size() );
+    grad( 0 )            = -w_terminal_altitude;
+    grad( 1 )            = w_terminal_velocity * ( state( 1 ) - desired_terminal_vel );
+    return grad;
+  };
+
+  problem.terminal_cost_hessian = [=]( const TerminalCostFunction&, const State& state ) {
+    Eigen::MatrixXd H = Eigen::MatrixXd::Zero( state.size(), state.size() );
+    H( 1, 1 )         = w_terminal_velocity;
+    return H;
+  };
+
+  problem.dynamics_state_jacobian = [=]( const MotionModel&, const State& state, const Control& control ) {
+    return examples::rocket_state_jacobian( params, state, control );
+  };
+
+  problem.dynamics_control_jacobian = [=]( const MotionModel&, const State& state, const Control& control ) {
+    return examples::rocket_control_jacobian( params, state, control );
+  };
+
+  Eigen::VectorXd u_lower( 1 ), u_upper( 1 );
+  u_lower << 0.0;
+  u_upper << max_thrust;
+  problem.input_lower_bounds = u_lower;
+  problem.input_upper_bounds = u_upper;
+
+  problem.initialize_problem();
+  problem.verify_problem();
+
+  return problem;
+}
+
+struct Options
+{
+  bool        show_help   = false;
+  bool        dump_traces = false;
+  std::string solver      = "osqp";
+};
+
+Options
+parse_options( int argc, char** argv )
+{
+  Options options;
+  for( int i = 1; i < argc; ++i )
+  {
+    const std::string arg = argv[i];
+    if( arg == "--help" || arg == "-h" )
+    {
+      options.show_help = true;
+      continue;
+    }
+    if( arg == "--dump" )
+    {
+      options.dump_traces = true;
+      continue;
+    }
+
+    const std::string solver_prefix = "--solver=";
+    if( arg.rfind( solver_prefix, 0 ) == 0 )
+    {
+      options.solver = arg.substr( solver_prefix.size() );
+      continue;
+    }
+
+    if( arg == "--solver" )
+    {
+      if( i + 1 >= argc )
+        throw std::invalid_argument( "Missing value for --solver" );
+      options.solver = argv[++i];
+      continue;
+    }
+
+    throw std::invalid_argument( "Unknown argument '" + arg + "'" );
+  }
+  return options;
+}
+
+void
+print_usage()
+{
+  std::cout << "Usage: rocket_max_altitude [--solver NAME] [--dump]\n";
+  std::cout << '\n';
+  examples::print_available( std::cout );
+}
+
+} // namespace
+
+int
+main( int argc, char** argv )
+{
+  using namespace mas;
+
+  try
+  {
+    const Options options = parse_options( argc, argv );
+    if( options.show_help )
+    {
+      print_usage();
+      return 0;
+    }
+
+    OCP problem = create_max_altitude_rocket_ocp();
+
+    SolverParams params;
+    params["max_iterations"] = 25;
+    params["tolerance"]      = 1e-6;
+    params["max_ms"]         = 200;
+
+    Solver solver = examples::make_solver( options.solver );
+    mas::set_params( solver, params );
+    mas::solve( solver, problem );
+
+    const auto& X = problem.best_states;
+    const int   T = problem.horizon_steps;
+
+    const double final_altitude = X( 0, T );
+    const double final_velocity = X( 1, T );
+
+    std::cout << std::fixed << std::setprecision( 3 );
+    std::cout << "Best cost: " << problem.best_cost << '\n';
+    std::cout << "Final altitude: " << final_altitude << " m\n";
+    std::cout << "Final velocity: " << final_velocity << " m/s\n";
+
+    if( options.dump_traces )
+    {
+      examples::print_state_trajectory( std::cout, X, problem.dt, "rocket" );
+      examples::print_control_trajectory( std::cout, problem.best_controls, problem.dt, "rocket" );
+    }
+  }
+  catch( const std::exception& ex )
+  {
+    std::cerr << "Error: " << ex.what() << '\n';
+    return 1;
+  }
+  return 0;
+}

--- a/include/multi_agent_solver/solvers/osqp_collocation.hpp
+++ b/include/multi_agent_solver/solvers/osqp_collocation.hpp
@@ -244,8 +244,12 @@ inline void
 OSQPCollocation::assemble_values( const OCP& p, const StateTrajectory& X, const ControlTrajectory& U, double reg )
 {
   qp.g.setZero();
-  for( int t = 1; t <= T; ++t )
-    qp.g.segment( id_state( t, 0, nx ), nx ) = p.cost_state_gradient( p.stage_cost, X.col( t ), U.col( std::min( t, T - 1 ) ), t );
+  for( int t = 1; t < T; ++t )
+    qp.g.segment( id_state( t, 0, nx ), nx ) =
+      p.cost_state_gradient( p.stage_cost, X.col( t ), U.col( std::min( t, T - 1 ) ), t );
+
+  if( T > 0 )
+    qp.g.segment( id_state( T, 0, nx ), nx ) = p.terminal_cost_gradient( p.terminal_cost, X.col( T ) );
   for( int t = 0; t < T; ++t )
     qp.g.segment( id_control( t, nx, nu, T ), nu ) = p.cost_control_gradient( p.stage_cost, X.col( t ), U.col( t ), t );
 
@@ -254,7 +258,7 @@ OSQPCollocation::assemble_values( const OCP& p, const StateTrajectory& X, const 
 
   constexpr double cache_eps = 1e-9;
 
-  for( int t = 1; t <= T; ++t )
+  for( int t = 1; t < T; ++t )
   {
     const auto x         = X.col( t );
     const auto u         = U.col( std::min( t, T - 1 ) );
@@ -279,6 +283,31 @@ OSQPCollocation::assemble_values( const OCP& p, const StateTrajectory& X, const 
 
     for( int i = 0; i < nx; ++i )
       h_val[H_idx[kH++]] = Q_cache[t]( i, i );
+  }
+
+  if( T > 0 )
+  {
+    const auto x         = X.col( T );
+    bool       recompute = !use_cache || !cache_valid || ( x - X_prev.col( T ) ).norm() > cache_eps;
+
+    if( recompute )
+    {
+      auto Q = p.terminal_cost_hessian( p.terminal_cost, x );
+      if( !Q.allFinite() )
+        std::cerr << "[Warning] Non-finite terminal Hessian\n";
+
+      double min_diag = Q.diagonal().minCoeff();
+      if( min_diag + reg < 0.0 )
+      {
+        double lambda         = std::abs( min_diag ) + reg;
+        Q.diagonal().array() += lambda;
+      }
+
+      Q_cache[T] = Q;
+    }
+
+    for( int i = 0; i < nx; ++i )
+      h_val[H_idx[kH++]] = Q_cache[T]( i, i );
   }
 
   for( int t = 0; t < T; ++t )

--- a/scripts/compare_solvers.py
+++ b/scripts/compare_solvers.py
@@ -19,6 +19,7 @@ MULTI_AGENT_EXAMPLES = {
 SINGLE_AGENT_EXAMPLES = {
     "single_track_ocp",
     "pendulum_swing_up",
+    "rocket_max_altitude",
 }
 
 ALL_EXAMPLES = tuple(sorted(MULTI_AGENT_EXAMPLES | SINGLE_AGENT_EXAMPLES))


### PR DESCRIPTION
## Summary
- include terminal cost gradients and Hessians when assembling OSQP and OSQP collocation QPs
- add a reusable vertical-rocket model and a max-altitude rocket example for testing terminal costs